### PR TITLE
chore: establish ChatGPT ↔ Codex workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,19 +4,114 @@
 This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` before writing any code. Heed deprecation notices.
 <!-- END:nextjs-agent-rules -->
 
+# ArgentQC agent governance
+
+## Roles
+
+- Product Owner = project owner; decides product direction and authorizes consequential releases/mutations.
+- ChatGPT = chief of staff, independent reviewer, context keeper, and author of durable GitHub work orders.
+- Codex = implementation and technical operations engineer executing the assigned GitHub Issue.
+- GitHub = durable technical memory: issues define work, PRs/commits/comments preserve execution evidence.
+
+Recommended operating convention: **1 GitHub Issue = 1 new Codex conversation**. An issue must be autonomous enough for a fresh Codex thread.
+
+## Required reading before significant work
+
+1. `AGENTS.md`
+2. `docs/PROJECT_STATE.md`
+3. Assigned GitHub Issue and its recent comments
+4. Relevant product, claims, data, SEO, architecture, or operational documentation
+
+Do not rely on a previous chat thread as the only source of requirements.
+
+## Sources of truth
+
+1. Versioned code / configuration / data = implementation truth
+2. `docs/PROJECT_STATE.md` = current operational snapshot and known state
+3. Assigned GitHub Issue = mandate, scope, authorization, acceptance criteria, and stop conditions
+4. PR / commits / GitHub comments = durable execution evidence
+5. Product / roadmap / editorial documentation = strategic direction
+
+Strategic documentation is **not** implicit authorization to mutate production, production data, external services, or unrelated code.
+
+## Git discipline
+
+Before work, Codex must inspect and report:
+
+- current branch and HEAD;
+- reference remote branch and its SHA;
+- ahead / behind;
+- worktree status;
+- existing diff;
+- untracked files;
+- pre-existing changes.
+
+Preserve all unrelated work. Use a dedicated branch and small targeted commits unless the Issue explicitly authorizes another workflow. Never hide, overwrite, reset, or opportunistically absorb unrelated user changes.
+
+## Production discipline
+
+Finding a problem does not authorize fixing it in PROD.
+
+Before any consequential mutation, verify:
+
+- environment;
+- deployed SHA/version when applicable;
+- exact target;
+- affected data/services;
+- explicit authorization in the Issue.
+
+If the production target or version cannot be established with confidence: **NO-GO**. Audit/findings are not automatic authorization to mutate, merge, deploy, or alter external data/services.
+
 ## Repo Commands
 
-- `npm run dev`: demarre Next.js en local sur `http://localhost:3000`
-- `npm run build`: execute `npm run check:seo` puis `next build`
-- `npm run check:seo`: valide le registre SEO, les routes statiques, les slugs du blog, les routes localisees et la propagation du questionnaire
-- `npm run test:unit`: lance les tests Node cibles sans build complet
-- `npm test`: lance `npm run test:unit` puis les smoke tests Playwright
-- `npm run test:ui`: ouvre Playwright en mode UI
-- `npm run indexnow`: soumet IndexNow via `scripts/submit-indexnow.mjs`
+Use only commands actually defined by the repository. Current versioned commands are:
+
+- `npm run dev`: starts Next.js locally.
+- `npm run build`: runs `npm run check:seo` then `next build`.
+- `npm run start`: starts the production Next.js server.
+- `npm run lint`: runs ESLint.
+- `npm run check:seo`: validates the SEO registry, static routes, blog slugs, localized routes, and questionnaire propagation.
+- `npm run indexnow`: submits IndexNow through `scripts/submit-indexnow.mjs`.
+- `npm run test:unit`: runs the targeted Node tests defined in `package.json`.
+- `npm test`: runs unit tests then Playwright smoke tests.
+- `npm run test:ui`: opens Playwright UI.
+
+Do not invent test/build/lint commands. Report exactly which commands ran, their result, which relevant commands did not run, CI status, and environment failures separately from product failures.
 
 ## Repo Workflows
 
-- Nouvelle page SEO statique: creer `src/app/<slug>/page.tsx`, exporter `metadata`, ajouter la route a `src/data/seo-pages.ts`, puis lancer `npm run check:seo`
-- Nouvel article de blogue: creer `src/data/blog/entries/<slug>.tsx`, laisser le sitemap XML, `/blog` et `/blog/<slug>` se regenerer depuis ce seul fichier, puis lancer `npm run check:seo`
-- Smoke tests Playwright: en local, la config demarre `npm run dev`; en CI avec `CI=1`, elle demarre `npx next start` apres le build
-- Netlify: le build execute `npm run build && npx playwright install chromium && npx playwright test`, avec cache des binaires Playwright dans `.playwright-browsers`
+- New static SEO page: create `src/app/<slug>/page.tsx`, export `metadata`, add the route to `src/data/seo-pages.ts`, then run `npm run check:seo`.
+- New blog article: create `src/data/blog/entries/<slug>.tsx`; sitemap XML, `/blog`, and `/blog/<slug>` derive from that source; run `npm run check:seo`.
+- Playwright locally starts `npm run dev`; with `CI=1`, configuration starts `npx next start` after the build.
+- Netlify production build is defined in `netlify.toml`: `npm run build && npx playwright install chromium && npx playwright test`, with Playwright browser cache under `.playwright-browsers`.
+- Sensitive 2026 financial values follow `docs/data-reliability-2026.md` and the source-backed claim ledgers under `docs/claims/`.
+
+## Findings classification
+
+- **P0** = corruption, data loss, critical incident, or dangerous behavior.
+- **P1** = blocker that must be resolved before release, deployment, or gate.
+- **P2** = real defect, non-blocking for the current gate.
+- **P3** = improvement, tuning, debt, or observation.
+
+An audit/gate is not permission to repair every P2/P3 opportunistically. Record out-of-scope findings and stop where the Issue says to stop.
+
+## Durable completion report
+
+When Codex finishes an Issue, publish the complete report in GitHub (Issue and/or linked PR). Include as applicable:
+
+- preflight;
+- work performed;
+- files changed;
+- commits;
+- PR;
+- commands/tests and results;
+- CI;
+- deployment;
+- data/metrics;
+- findings with P0-P3 classification;
+- GO / NO-GO;
+- remaining risks;
+- safest next action;
+- deviations from mandate.
+
+Never require the Product Owner to copy the report manually into ChatGPT. ChatGPT reviews the durable GitHub evidence independently.

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -1,0 +1,100 @@
+# ArgentQC — PROJECT STATE
+
+Operational source of truth. Keep this compact; detailed backlog belongs in GitHub Issues.
+
+**Snapshot:** 2026-08-28. Temporal release facts below are snapshots, not permanent truths.
+
+## Product
+
+ArgentQC (`argentqc.ca`) is a French/English Quebec-focused personal-finance information and discovery site. The current product surfaces financial programs and practical guides, with a questionnaire/matching funnel and topic hubs covering budget/financial assistance, taxes, retirement, insurance, internet and moving. The site also publishes SEO guides/blog content and calculators/comparators.
+
+The product handles financially sensitive claims. Official values, estimates, editorial assumptions, eligibility rules, dates, rates and thresholds must be distinguished and source-backed according to the versioned data/claims documentation.
+
+## Architecture
+
+- Repository: `Simultima-qc/argentqc`.
+- Framework: Next.js 16.2.1 / React 19.2.4 / TypeScript.
+- Styling/tooling: Tailwind CSS 4, ESLint 9.
+- App structure: Next.js App Router under `src/app`, including localized routes.
+- Content/data: versioned TypeScript/JSON under `src/data`; financial 2026 modules under `src/data/finance-2026`; source-backed claim ledgers under `docs/claims`.
+- Email dependency: Resend is versioned as an application dependency; exact production usage/configuration is not asserted by this snapshot.
+- Tests: Node targeted unit tests plus Playwright smoke tests.
+- SEO validation: `scripts/check-seo.mjs` via `npm run check:seo` and as part of `npm run build`.
+- Hosting: Netlify with `@netlify/plugin-nextjs`.
+- Database: **Non vérifié / none established from the audited versioned configuration.**
+- GitHub Actions: no `.github/workflows` directory was present in the audited `main` tree; deployment validation is primarily observable through Netlify for the current setup.
+
+## Release state
+
+Snapshot verified 2026-08-28 before this governance change:
+
+- Default branch: `main`.
+- PROD branch: `main`, verified from the current Netlify production deploy.
+- Pre-governance `main` HEAD: `8c9a745b30e4613543873501947a03917c418dab` (`Securise le JSON-LD des pages prioritaires`).
+- Hosting project: Netlify site `argentqc`, primary URL `https://argentqc.ca`.
+- Verified production deploy before governance: Netlify deploy `6a8a4d912bc77a0008429c11`, state `ready`, context `production`, branch `main`, commit `8c9a745b30e4613543873501947a03917c418dab`, published 2026-08-23.
+- Netlify build command: `npm run build && npx playwright install chromium && npx playwright test`.
+- GitHub open Issues at audit start: none.
+- GitHub open PRs at audit start: none.
+- GitHub Actions workflows at audit start: none established in repository.
+- Environment variables/secrets: **Non vérifié**; do not infer values or mutate them without an explicit Issue.
+
+## Functional state
+
+Verified from repository and recent durable history:
+
+- Localized home and topic surfaces are implemented.
+- Questionnaire/matching, SEO route registry, blog/guides, calculators/comparators and financial-program data are versioned.
+- Data-reliability conventions exist for sensitive 2026 financial datasets.
+- Source-backed claim ledgers exist for multiple priority financial articles.
+- Recent delivered work includes audits of assurance-emploi, aide sociale, SRG, RQAP and Sécurité de la vieillesse claims; SRG questionnaire funnel optimization; homepage trust improvements; and hardened JSON-LD serialization for priority pages.
+- Latest verified PROD before governance is healthy at the hosting layer (`ready`). Full independent browser/content smoke of every surface: **Non vérifié** in this snapshot.
+
+## Known blockers
+
+No P0/P1 blocker was established by the 2026-08-28 repository/hosting audit.
+
+Do not promote old observations from documentation to P0/P1 without reproducing them against current code/PROD.
+
+## Gates / workstreams closed
+
+Durable Git history establishes completion of these recent workstreams:
+
+- source-backed claim ledgers introduced;
+- assurance-emploi 2026 claims audit;
+- aide sociale 2026 claims audit;
+- SRG 2026 claims audit;
+- RQAP 2026 claims audit;
+- Sécurité de la vieillesse 2026 claims audit;
+- SRG → questionnaire funnel optimization;
+- homepage trust reinforcement;
+- priority JSON-LD hardening and hostile serialization test.
+
+## NEXT WORKSTREAM
+
+**Re-baseline the current SEO/content priority from actual production/search evidence and current code, then produce a ranked, source-backed next-action plan before making further SEO content changes.**
+
+Reason: the repository has no open Issues/PRs, recent priority financial claim work has materially advanced beyond older roadmap notes, and the next product/SEO target cannot be selected safely from stale documentation alone. The first operational Issue should therefore be a bounded read-only prioritization audit with explicit stop-before-mutation.
+
+## Hard rules
+
+- One GitHub Issue should normally map to one fresh Codex conversation.
+- Read `AGENTS.md`, this file, the assigned Issue/comments, and relevant domain docs before significant work.
+- GitHub Issue scope is the authorization boundary.
+- Audit/findings do not authorize mutation.
+- Never change PROD/external services/data unless explicitly authorized and the target/version are verified.
+- Preserve unrelated work and report pre-existing changes.
+- Use only repository-defined commands; never invent tests.
+- Financially sensitive claims require source-backed handling and status discipline.
+- New SEO routes must respect route/canonical/sitemap/localization conventions and `npm run check:seo`.
+- Keep `PROJECT_STATE.md` operational and compact; use Issues for detailed backlog/history.
+
+## Structural backlog
+
+Non-prioritized until validated by a current Issue:
+
+- Continue centralizing repeated sensitive financial values from blog/pages into shared versioned data modules where justified.
+- Add/strengthen automated validation of financial dataset metadata and freshness where useful.
+- Reassess remaining React/Next.js warnings/deprecations against the current Next.js version before scheduling fixes.
+- Continue route/localization/canonical governance and contract coverage as SEO surfaces evolve.
+- Replace the generic scaffold `README.md` with accurate contributor/project documentation when that becomes a scoped documentation workstream.


### PR DESCRIPTION
## Summary

Establishes the durable Product Owner → ChatGPT → GitHub → Codex workflow for ArgentQC.

Changes are intentionally limited to:
- `AGENTS.md` — preserves existing Next.js/repo guidance and adds roles, source-of-truth hierarchy, Git/PROD/test discipline, findings classification and durable reporting rules.
- `docs/PROJECT_STATE.md` — adds a compact operational snapshot based on the repository and verified Netlify production state.

Functional impact: none.

## Audit baseline

- Default/PROD branch: `main`
- Baseline SHA: `8c9a745b30e4613543873501947a03917c418dab`
- Netlify production deploy at baseline: `6a8a4d912bc77a0008429c11`, `ready`, same commit SHA
- Open Issues at audit start: 0
- Open PRs at audit start: 0
- `.github/workflows`: absent

## Validation

Documentation-only change. No product code/config/data changed. Repository-defined product tests are not necessary to establish runtime behavior for this diff; Netlify deployment after merge will remain the production health check because merging `main` triggers the configured site build.

Independent review should confirm the diff contains only the two documentation files before merge.