### PR TITLE
Corriger la fréquence de l’Allocation famille en anglais

### DIFF
--- a/src/app/aide-financiere-sport-enfant-quebec/page.tsx
+++ b/src/app/aide-financiere-sport-enfant-quebec/page.tsx
@@ -28,7 +28,7 @@ const programmes = [
     nom: "Allocation famille (Québec)",
     organisme: "Retraite Québec",
     montant: "Jusqu'à 3 068 $/enfant/an — à vérifier",
-    description: "Versements mensuels non imposables pour familles québécoises avec enfants de moins de 18 ans.",
+    description: "Versements trimestriels par défaut pour les familles québécoises admissibles avec enfants de moins de 18 ans; des versements mensuels peuvent être demandés.",
     href: "/aide-famille-quebec",
     badge: "Provincial",
     badgeColor: "bg-blue-100 text-blue-700",

--- a/src/app/subvention-sport-enfant-quebec/page.tsx
+++ b/src/app/subvention-sport-enfant-quebec/page.tsx
@@ -21,7 +21,7 @@ const programmes: Programme[] = [
     montant_affiche: "Jusqu'à 3 068 $ par enfant en 2026 — à vérifier",
     montant_sommable: false,
     preselection_only: true,
-    description: "Versements mensuels non imposables pour les familles québécoises ayant des enfants de moins de 18 ans. Ce revenu supplémentaire peut couvrir les frais d'inscription aux activités sportives.",
+    description: "Versements trimestriels par défaut pour les familles québécoises admissibles ayant des enfants de moins de 18 ans; des versements mensuels peuvent être demandés.",
     conditions: [
       "Résider au Québec",
       "Avoir au moins un enfant de moins de 18 ans",

--- a/src/data/blog/entries/allocation-canadienne-enfants-2026.tsx
+++ b/src/data/blog/entries/allocation-canadienne-enfants-2026.tsx
@@ -138,9 +138,9 @@ function Content() {
         <section className="mb-8">
           <h2 className="text-xl font-bold text-slate-800 mb-3">ACE et Allocation famille : deux aides distinctes</h2>
           <p className="text-slate-600 leading-relaxed mb-4">
-            Beaucoup de parents ne réalisent pas qu&apos;ils reçoivent <strong>deux prestations séparées</strong>{" "}chaque mois :
-            l&apos;ACE fédérale (ARC) et l&apos;Allocation famille provinciale (Retraite Québec). Ces deux programmes
-            sont cumulables et indépendants.
+            Beaucoup de parents ne réalisent pas qu&apos;il s&apos;agit de <strong>deux prestations séparées</strong> :
+            l&apos;ACE fédérale est mensuelle, tandis que l&apos;Allocation famille provinciale est trimestrielle par défaut
+            et peut être versée mensuellement sur demande. Ces deux programmes sont cumulables et indépendants.
           </p>
           <div className="grid grid-cols-1 gap-3">
             {[

--- a/src/data/blog/entries/allocation-famille-quebec-calcul-2026.tsx
+++ b/src/data/blog/entries/allocation-famille-quebec-calcul-2026.tsx
@@ -7,7 +7,7 @@ const slug = "allocation-famille-quebec-calcul-2026";
 const baseMetadata: Metadata = {
   title: "Allocation famille Québec 2026 : Calculez combien vous recevez",
   description:
-    "Allocation famille Québec 2026 : montants selon le nombre d'enfants et le revenu familial, comment calculer votre aide, versements mensuels de Retraite Québec.",
+    "Allocation famille Québec 2026 : montants, calcul, paiements trimestriels par défaut et option de versements mensuels sur demande.",
   keywords: ["allocation famille québec 2026", "allocation famille montant", "allocation famille calcul", "retraite québec enfants", "aide famille québec"],
 };
 
@@ -163,7 +163,7 @@ function Content() {
           <h2 className="text-xl font-bold text-slate-800 mb-3">Suppléments additionnels disponibles</h2>
           <p className="text-slate-600 leading-relaxed mb-4">
             En plus du montant de base, certaines familles ont droit à des suppléments qui s&apos;ajoutent
-            automatiquement à l&apos;allocation mensuelle.
+            à l&apos;Allocation famille selon les règles propres à chaque supplément.
           </p>
           <div className="grid grid-cols-1 gap-3">
             {[
@@ -323,7 +323,7 @@ function Content() {
 const article: BlogArticle = {
   slug,
   titre: "Allocation famille Québec 2026 : Calculez combien vous recevez",
-  description: "Montants de l'allocation famille Québec 2026, comment calculer votre aide selon votre revenu et le nombre d'enfants, suppléments disponibles et versements mensuels.",
+  description: "Montants de l'Allocation famille Québec 2026, calcul, suppléments, paiements trimestriels par défaut et option mensuelle sur demande.",
   date: "2026-05-21",
   categorie: "Famille",
   tempsLecture: "8 min",

--- a/src/i18n/programmes.ts
+++ b/src/i18n/programmes.ts
@@ -73,7 +73,7 @@ const enProgrammeTranslations: Record<string, ProgrammeTranslation> = {
     organisme: "Retraite Quebec",
     montant_affiche: "Up to $3,068 per child in 2026 — verify",
     description:
-      "Monthly payments for Quebec families with children under 18. This is paid in addition to the Canada Child Benefit.",
+      "Quarterly payments by default for eligible Quebec families with children under 18; monthly payments can be requested.",
     conditions: [
       "You must live in Quebec",
       "You must have at least one child under 18",

--- a/tests/ace-ccf.test.mjs
+++ b/tests/ace-ccf.test.mjs
@@ -23,6 +23,36 @@ test("ACE and Allocation famille questionnaire entries remain preselection-only"
   }
 });
 
+test("Allocation famille frequency stays quarterly by default in French and English", () => {
+  const english = read("src/i18n/programmes.ts");
+  const frenchSurfaces = [
+    "src/data/programmes.json",
+    "src/app/allocation-enfant-quebec/page.tsx",
+    "src/app/aide-famille-quebec/page.tsx",
+    "src/app/aide-financiere-sport-enfant-quebec/page.tsx",
+    "src/app/subvention-sport-enfant-quebec/page.tsx",
+    "src/data/blog/entries/allocation-canadienne-enfants-2026.tsx",
+    "src/data/blog/entries/allocation-famille-quebec-calcul-2026.tsx",
+  ].map(read).join("\n");
+
+  assert.match(
+    english,
+    /Quarterly payments by default for eligible Quebec families with children under 18; monthly payments can be requested\./
+  );
+  assert.doesNotMatch(english, /Monthly payments for Quebec families with children under 18/i);
+
+  for (const staleClaim of [
+    /Versements mensuels non imposables pour (?:les )?familles québécoises/i,
+    /versements mensuels de Retraite Québec/i,
+    /deux prestations séparées[^.]*chaque mois/i,
+    /allocation mensuelle/i,
+  ]) {
+    assert.doesNotMatch(frenchSurfaces, staleClaim);
+  }
+
+  assert.match(frenchSurfaces, /trimestriels? par défaut[^.]*mensuels? (?:peuvent être demandés|sur demande)/i);
+});
+
 test("central 2026 rules contain the audited ACE, Quebec and CCF parameters", () => {
   const source = read("src/data/finance-2026/family-training-rules-2026.ts");
   for (const token of [


### PR DESCRIPTION
## Résumé
- corrige la description anglaise de l’Allocation famille : paiements trimestriels par défaut, mensuels sur demande
- aligne les formulations françaises directement liées découvertes pendant la vérification
- ajoute un test de régression FR/EN ciblé dans la suite ACE/CCF existante

## Périmètre
- 6 fichiers modifiés
- aucun changement fonctionnel hors fréquence d’affichage
- checkout original préservé

## Validation
- node --test tests/ace-ccf.test.mjs : 6/6
- npm run test:unit : 45/45
- npm run lint : réussi
- npm run check:seo : réussi
- npm run build : réussi, 165 pages générées
- git diff --check : réussi

Closes #9