### PR TITLE
Corrige le RAP dans le total du questionnaire (non sommable)

### DIFF
--- a/src/data/programmes.json
+++ b/src/data/programmes.json
@@ -53,6 +53,8 @@
     "montant_min": 0,
     "montant_max": 35000,
     "montant_affiche": "Retrait REER jusqu'à 35 000 $ (à rembourser en 15 ans)",
+    "montant_sommable": false,
+    "preselection_only": true,
     "description": "Le RAP permet de retirer jusqu'à 35 000 $ de votre REER sans impôt immédiat pour l'achat d'une première propriété. Ce n'est pas une aide gratuite : la somme doit être remboursée dans votre REER sur au plus 15 ans. Les tranches non remboursées sont ajoutées à votre revenu imposable chaque année. Pertinent si vous avez déjà des économies dans un REER et envisagez l'achat d'une première maison.",
     "conditions": [
       "Être acheteur d'une première propriété (ou ne pas avoir été propriétaire depuis au moins 4 ans)",

--- a/tests/programmes-matching.test.mjs
+++ b/tests/programmes-matching.test.mjs
@@ -234,6 +234,37 @@ test("RRQ remains an orientation-only, non-summable lead", () => {
   );
 });
 
+test("RAP remains an orientation-only, non-summable lead", () => {
+  const programmes = loadProgrammesJson();
+  const rap = programmes.find((programme) => programme.id === "reer-subvention-fed");
+
+  assert.ok(rap);
+  assert.equal(rap.preselection_only, true);
+  assert.equal(rap.montant_sommable, false);
+  assert.equal(
+    JSON.stringify(calculerTotal([rap, { ...rap, id: "summable", montant_sommable: true, montant_min: 100, montant_max: 200 }])),
+    JSON.stringify({ min: 100, max: 200 }),
+  );
+});
+
+test("RAP appears as a lead for a matching renter profile but is excluded from the total", () => {
+  const matched = trouverProgrammes(makeAnswers({
+    statut_logement: "locataire",
+    revenu: "30000-50000",
+  }));
+  const ids = programmeIds(matched);
+
+  assert.ok(ids.has("reer-subvention-fed"), "RAP should still surface as a lead for an eligible renter");
+
+  const rap = matched.find((programme) => programme.id === "reer-subvention-fed");
+  assert.equal(rap.preselection_only, true);
+  assert.equal(rap.montant_sommable, false);
+
+  const totalWithRap = calculerTotal(matched);
+  const totalWithoutRap = calculerTotal(matched.filter((programme) => programme.id !== "reer-subvention-fed"));
+  assert.deepEqual(totalWithRap, totalWithoutRap, "35 000 $ from RAP must not be added to the total");
+});
+
 test("trouverProgrammes matches a student", () => {
   const ids = programmeIds(trouverProgrammes(makeAnswers({
     age: "18-30",


### PR DESCRIPTION
## Contexte

Suite au re-baseline #31 (GO), le RAP (`reer-subvention-fed`) était additionné au total des « programmes chiffrables » du questionnaire alors qu'il s'agit d'un retrait REER remboursable, pas d'une aide gratuite (jusqu'à 35 000 $ sur un total d'environ 60 650 $ pour un profil locataire type, soit ~57,7 %).

## Changement

Dans `src/data/programmes.json`, le programme `reer-subvention-fed` reçoit désormais :

```json
"montant_sommable": false,
"preselection_only": true
```

Même traitement que le REEP (`reep-etudes-canada`) et la RRQ (`rrq-rentes-qc`), mécanismes structurellement comparables déjà non sommables.

## Comportement avant / après

- **Avant** : le RAP apparaissait dans les résultats **et** ses 35 000 $ étaient additionnés au total générique (`calculerTotal()` dans `src/lib/matching.ts`), gonflant artificiellement le montant affiché à l'utilisateur.
- **Après** : le RAP continue d'apparaître comme piste d'orientation pour les profils correspondants, mais n'est plus jamais additionné au total (il est exclu par le filtre `montant_sommable !== false` déjà utilisé pour REEP/RRQ et par tous les autres calculs de total du site : `SeoProgrammesPage.tsx`, `LocalizedBudgetHousingAllowancePage.tsx`, `LocalizedBudgetSolidarityCreditPage.tsx`).

Aucune logique de matching, aucun critère, aucun champ questionnaire n'a été modifié. Pas de calculateur RAP ajouté (hors scope de l'issue).

## Test de régression

`tests/programmes-matching.test.mjs` — 2 nouveaux tests, réutilisant le pattern déjà en place pour la RRQ :

1. `RAP remains an orientation-only, non-summable lead` — vérifie `preselection_only:true`, `montant_sommable:false`, et l'exclusion de `calculerTotal()`.
2. `RAP appears as a lead for a matching renter profile but is excluded from the total` — vérifie que le RAP est toujours sélectionné par `trouverProgrammes()` pour un profil locataire éligible, et que le total avec/sans RAP est strictement identique (les 35 000 $ ne sont plus additionnés).

## Recherche finale ciblée

Vérification de `reer-subvention-fed`, « RAP », « 35 000 », `montant_sommable`, `preselection_only` dans `src/` : l'identifiant du programme n'apparaît que dans le catalogue (`programmes.json`) et les libellés de traduction (`i18n/programmes.ts`, affichage uniquement). Aucune autre logique n'additionne le RAP séparément — tous les calculs de total du site filtrent déjà sur `montant_sommable !== false`.

## QA (environnement avec dépendances réellement installées via `npm ci`)

- `node --test tests/programmes-matching.test.mjs` → **11/11 verts** (incluant les 2 nouveaux tests)
- `npm run test:unit` → **125/125 verts**
- `npm run check:seo` → **passe** (4 avertissements de fraîcheur de claims préexistants et non liés au RAP, non bloquants)
- `npm run lint` → **0 erreur**
- `npm run build` → **succès** (TypeScript + 166 pages générées)
- `git diff --check` → **0 problème**

## Fichiers modifiés

- `src/data/programmes.json` (2 lignes ajoutées)
- `tests/programmes-matching.test.mjs` (31 lignes ajoutées)

Aucun autre programme n'a été modifié. Aucun nouveau champ questionnaire, aucun calculateur RAP, aucune modification de `ReponseQuestionnaire` ou du funnel.

## Limites

- Le RAP reste une préselection d'orientation, sans calcul d'admissibilité réelle (hors scope, conformément à l'issue).
- Les avertissements de fraîcheur de claims (`check:seo`) sont préexistants et non liés à ce correctif.

## Stop condition

Conformément à l'issue #32 : pas de merge automatique, pas de déploiement manuel, pas d'enchaînement sur la revalidation SV/SRG ou un autre item du Top 5 de #31.

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G6CDN4TCuZn7PpecfHbd9S

---
_Generated by [Claude Code](https://claude.ai/code/session_01G6CDN4TCuZn7PpecfHbd9S)_