### PR TITLE
Retire l'infrastructure AdSense inutilisée causant le popup de consentement publicitaire

### DIFF
--- a/public/ads.txt
+++ b/public/ads.txt
@@ -1,1 +1,0 @@
-google.com, pub-2932496105657945, DIRECT, f08c47fec0942fa0

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -30,14 +30,6 @@ export default function RootLayout({
             gtag('config', 'G-EHYFT9BFCN');
           `}
         </Script>
-
-        {/* Google AdSense – Auto ads */}
-        <Script
-          async
-          src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-2932496105657945"
-          crossOrigin="anonymous"
-          strategy="lazyOnload"
-        />
       </head>
       <body className="min-h-full flex flex-col bg-slate-50 text-slate-900">
         {children}

--- a/src/app/politique-confidentialite/page.tsx
+++ b/src/app/politique-confidentialite/page.tsx
@@ -9,7 +9,7 @@ const PARCH = "#F7F3EC";
 export const metadata: Metadata = {
   title: "Politique de confidentialité – ArgentQC.ca",
   description:
-    "Politique de confidentialité d'ArgentQC.ca : utilisation des données, cookies publicitaires (Google AdSense) et cookies d'analyse (Google Analytics).",
+    "Politique de confidentialité d'ArgentQC.ca : utilisation des données et cookies d'analyse (Google Analytics).",
 };
 
 export default function PolitiqueConfidentialite() {
@@ -45,7 +45,7 @@ export default function PolitiqueConfidentialite() {
           Politique de confidentialité
         </h1>
         <p className="mb-10 text-sm text-slate-500">
-          Dernière mise à jour : avril 2026
+          Dernière mise à jour : septembre 2026
         </p>
 
         <div className="flex flex-col gap-8 text-sm leading-7 text-slate-700">
@@ -95,30 +95,7 @@ export default function PolitiqueConfidentialite() {
 
           <section>
             <h2 className="mb-3 text-lg font-extrabold text-slate-800">
-              4. Google AdSense et publicités
-            </h2>
-            <p>
-              ArgentQC.ca utilise Google AdSense pour afficher des publicités. Google AdSense peut utiliser des
-              cookies et des technologies similaires pour afficher des annonces personnalisées basées sur vos
-              visites sur ce site et sur d&apos;autres sites.
-            </p>
-            <p className="mt-3">
-              Google utilise le cookie DoubleClick pour diffuser des annonces pertinentes. Vous pouvez consulter
-              la politique de confidentialité de Google et gérer vos préférences publicitaires sur :{" "}
-              <span className="font-medium text-slate-600">
-                adssettings.google.com
-              </span>
-            </p>
-            <p className="mt-3">
-              Les annonceurs tiers peuvent également utiliser des cookies pour mesurer les performances de
-              leurs publicités. Ces cookies sont soumis aux politiques de confidentialité des annonceurs concernés,
-              sur lesquelles nous n&apos;avons pas de contrôle.
-            </p>
-          </section>
-
-          <section>
-            <h2 className="mb-3 text-lg font-extrabold text-slate-800">
-              5. Cookies
+              4. Cookies
             </h2>
             <p>
               Les cookies sont de petits fichiers texte déposés sur votre appareil lors de la navigation.
@@ -126,7 +103,6 @@ export default function PolitiqueConfidentialite() {
             </p>
             <ul className="mt-3 space-y-2 pl-5 list-disc">
               <li>Mesurer l&apos;audience et améliorer le contenu (Google Analytics)</li>
-              <li>Afficher des publicités pertinentes (Google AdSense)</li>
               <li>Mémoriser des préférences d&apos;utilisation (ex. : état de la checklist déménagement)</li>
             </ul>
             <p className="mt-3">
@@ -137,7 +113,7 @@ export default function PolitiqueConfidentialite() {
 
           <section>
             <h2 className="mb-3 text-lg font-extrabold text-slate-800">
-              6. Liens externes
+              5. Liens externes
             </h2>
             <p>
               ArgentQC.ca contient des liens vers des sites gouvernementaux et des ressources tierces. Nous
@@ -148,7 +124,7 @@ export default function PolitiqueConfidentialite() {
 
           <section>
             <h2 className="mb-3 text-lg font-extrabold text-slate-800">
-              7. Modifications
+              6. Modifications
             </h2>
             <p>
               Nous pouvons mettre à jour cette politique de confidentialité à tout moment. La date de la
@@ -159,7 +135,7 @@ export default function PolitiqueConfidentialite() {
 
           <section>
             <h2 className="mb-3 text-lg font-extrabold text-slate-800">
-              8. Nous contacter
+              7. Nous contacter
             </h2>
             <p>
               Pour toute question relative à cette politique de confidentialité, vous pouvez nous écrire à :{" "}


### PR DESCRIPTION
## Contexte

Résout #55 : un popup de consentement publicitaire trompeur ("Publicités et contenu personnalisés, mesure de performance des publicités et du contenu…") apparaît à l'ouverture d'ArgentQC.ca alors qu'aucune publicité n'y est réellement diffusée.

## Cause exacte identifiée

`src/app/layout.tsx` (root layout, appliqué à toutes les routes FR/EN) chargeait sans condition le script Google AdSense Auto ads :

```html
<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-2932496105657945" ...>
```

Aucun emplacement publicitaire (`<ins class="adsbygoogle">`) n'existe nulle part dans le code — le site ne diffuse donc effectivement aucune publicité. Le seul rôle de ce script était de charger l'infrastructure AdSense.

**Chaîne exacte** : lorsque `adsbygoogle.js` est chargé avec un `client=ca-pub-…` valide, Google déclenche automatiquement, côté compte AdSense (configuration "Privacy & Messaging" / Funding Choices), le message de consentement standard "Publicités et contenu personnalisés…" — indépendamment de tout code présent dans ce dépôt. C'est une configuration au niveau du compte Google AdSense associé à `ca-pub-2932496105657945`, pas un CMP/GTM/Consent Mode implémenté ici (aucune trace de `fundingchoices`, GTM container, ou Consent Mode dans le code).

Infrastructure publicitaire résiduelle trouvée et retirée en conséquence :
- `src/app/layout.tsx` : script `adsbygoogle.js` (Auto ads).
- `public/ads.txt` : fichier d'autorisation AdSense (`google.com, pub-2932496105657945, DIRECT, ...`), inutile sans script AdSense actif.
- `src/app/politique-confidentialite/page.tsx` : sections/mentions décrivant l'usage d'AdSense (honnêteté du contenu — la politique ne doit pas prétendre à des traitements publicitaires qui n'ont plus lieu).

GA4 (`gtag`, `G-EHYFT9BFCN`) est laissé **intact** — aucune suppression, aucun changement de configuration.

## Ce qui n'a PAS été touché

- GA4 / Google Analytics : intact.
- Consent Mode : aucune implémentation de Consent Mode n'existait dans le code ; rien à désactiver.
- Aucun masquage CSS/JS du popup n'a été utilisé — la cause racine (le script) est supprimée.

## Fichiers modifiés

- `src/app/layout.tsx` — retrait du `<Script>` AdSense.
- `public/ads.txt` — supprimé.
- `src/app/politique-confidentialite/page.tsx` — retrait des sections/mentions AdSense (metadata description, section "Google AdSense et publicités", puce cookies publicitaires), renumérotation des sections, date de mise à jour.

## Comportement avant/après

- **Avant** : `adsbygoogle.js` chargé sur chaque page (FR et EN) → déclenchement du message de consentement Google mentionnant des publicités personnalisées inexistantes.
- **Après** : plus aucune référence à `adsbygoogle`/`googlesyndication`/`ca-pub` dans le HTML rendu (vérifié sur `/fr` et `/en` via build de production locale). GA4 (`G-EHYFT9BFCN`) toujours présent et fonctionnel sur les deux locales.

## Tests exécutés

- `npm run lint` → OK (aucune erreur).
- `npm run test:unit` → 182/182 tests passent.
- `npm run check:seo` (inclus dans `npm run build`) → OK, 67 routes statiques + 29 articles de blog validés.
- `npm run build` (`next build`) → succès, 166 pages générées.
- Vérification manuelle via `next start` en local :
  - `/fr` et `/en` : 0 occurrence de `adsbygoogle`/`googlesyndication`/`ca-pub` ; `G-EHYFT9BFCN` (GA4) présent.
  - `/politique-confidentialite` : 0 occurrence d'"AdSense".
  - `/ads.txt` : 404 (fichier retiré).
- Accès direct à `argentqc.ca` (PROD) impossible depuis cet environnement (`EGRESS_BLOCKED` — politique du proxy sortant de la session), donc pas de reproduction live du popup en PROD dans cette session ; la cause a été établie par lecture directe du code déployé (branche à jour avec `origin/main`) et le comportement standard documenté de Google AdSense/Privacy & Messaging, qui correspond exactement au libellé rapporté dans l'issue.

## Limites / risques résiduels

- Non vérifié en environnement PROD réel faute d'accès réseau sortant depuis cette session ; à confirmer par un accès direct à `https://argentqc.ca` après déploiement de cette PR (nouvelle visite en navigation privée, FR et EN, mobile et desktop) pour confirmer la disparition du popup.
- Si le popup persistait malgré cette PR (peu probable vu la cause identifiée), cela indiquerait une configuration résiduelle côté compte Google Ads/AdSense/Search Console externe au dépôt (ex. tag Funding Choices ajouté indépendamment via Google Tag Manager côté compte Google, hors du code source) — à vérifier manuellement dans la console AdSense/Ad Manager associée à `pub-2932496105657945` (section Privacy & messaging) si le symptôme réapparaît.
- Le fichier `public/robots.txt`/`sitemap.xml` n'a pas été affecté ; `npm run check:seo` confirme l'absence de régression sur le registre SEO.

## Conformité au mandat de l'issue #55

- [x] Source exacte du popup identifiée et documentée (script AdSense Auto ads).
- [x] Cause du wording publicitaire comprise (config compte AdSense/Privacy & Messaging, déclenchée par la présence du script).
- [x] Aucun masquage CSS/JS utilisé — suppression de la cause racine.
- [x] GA4 non supprimé.
- [x] Consent Mode non désactivé (n'existait pas).
- [x] FR/EN vérifiés (build + rendu HTML).
- [x] Lint/tests/build pertinents passent.
- [ ] Vérification finale en PROD réelle (mobile/desktop) — à faire après déploiement, accès réseau non disponible dans cette session.

## Stop condition

Conformément au mandat : modification de code nécessaire → PR ouverte, **pas de merge**. La revue indépendante et la décision finale reviennent au Product Owner / reviewer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KxKEAjpJbPa2W1BYGPreXU

---
_Generated by [Claude Code](https://claude.ai/code/session_01KxKEAjpJbPa2W1BYGPreXU)_