### PR TITLE
Corrige le bucketing d'âge du matching pour éliminer les faux positifs/négatifs (issue #58)

### DIFF
--- a/src/components/LocalizedResultsPage.tsx
+++ b/src/components/LocalizedResultsPage.tsx
@@ -25,7 +25,9 @@ interface LocalizedResultsPageProps {
 }
 
 export function getConfidenceTier(programme: Programme): "principal" | "verifier" {
-  return programme.niveau === "municipal" || programme.preselection_only ? "verifier" : "principal";
+  return programme.niveau === "municipal" || programme.preselection_only || programme.admissibiliteAgeIncertaine
+    ? "verifier"
+    : "principal";
 }
 
 function getTierRank(programme: ProgrammeWithMeta): number {
@@ -48,6 +50,11 @@ function getProgrammeReason(programme: Programme, reponses: ReponseQuestionnaire
     return fr
       ? "Préfiltre seulement : le questionnaire ne vérifie pas les conditions complètes de ce programme."
       : "Pre-filter only: the questionnaire does not verify this program's complete requirements.";
+
+  if (programme.admissibiliteAgeIncertaine)
+    return fr
+      ? "Votre tranche d'âge chevauche le seuil d'âge de ce programme : votre admissibilité exacte reste à vérifier."
+      : "Your age range overlaps this program's age threshold: your exact eligibility still needs to be verified.";
 
   if (c.proprietaire && reponses.statut_logement === "proprietaire")
     return fr ? "Vous avez indiqué être propriétaire." : "You indicated you are a homeowner.";

--- a/src/components/LocalizedResultsPage.tsx
+++ b/src/components/LocalizedResultsPage.tsx
@@ -30,6 +30,19 @@ export function getConfidenceTier(programme: Programme): "principal" | "verifier
     : "principal";
 }
 
+// issue #58: a programme whose age eligibility is uncertain must not be
+// presented in the hero summary as a confirmed amount (calculerTotal already
+// excludes it from the certain total — the display must match).
+export function getHeroRowDisplay(
+  programme: Programme,
+  verifierLabel: string
+): { icon: string; iconColor: string; value: string; valueColor?: string } {
+  if (programme.admissibiliteAgeIncertaine) {
+    return { icon: "?", iconColor: GOLD, value: verifierLabel, valueColor: GOLD };
+  }
+  return { icon: "✓", iconColor: GREEN, value: programme.montant_affiche };
+}
+
 function getTierRank(programme: ProgrammeWithMeta): number {
   return programme.tier === "principal" ? 0 : 1;
 }
@@ -42,19 +55,21 @@ export function sortProgrammesForTopPistes(programmes: ProgrammeWithMeta[]): Pro
   });
 }
 
-function getProgrammeReason(programme: Programme, reponses: ReponseQuestionnaire, locale: Locale): string {
+export function getProgrammeReason(programme: Programme, reponses: ReponseQuestionnaire, locale: Locale): string {
   const c = programme.criteres;
   const fr = locale === "fr";
+
+  // Age ambiguity takes priority: it is the more specific reason and must
+  // surface even for programmes that are also preselection_only (e.g. RQAP, RRQ).
+  if (programme.admissibiliteAgeIncertaine)
+    return fr
+      ? "Votre tranche d'âge chevauche le seuil d'âge de ce programme : votre admissibilité exacte reste à vérifier."
+      : "Your age range overlaps this program's age threshold: your exact eligibility still needs to be verified.";
 
   if (programme.preselection_only)
     return fr
       ? "Préfiltre seulement : le questionnaire ne vérifie pas les conditions complètes de ce programme."
       : "Pre-filter only: the questionnaire does not verify this program's complete requirements.";
-
-  if (programme.admissibiliteAgeIncertaine)
-    return fr
-      ? "Votre tranche d'âge chevauche le seuil d'âge de ce programme : votre admissibilité exacte reste à vérifier."
-      : "Your age range overlaps this program's age threshold: your exact eligibility still needs to be verified.";
 
   if (c.proprietaire && reponses.statut_logement === "proprietaire")
     return fr ? "Vous avez indiqué être propriétaire." : "You indicated you are a homeowner.";
@@ -221,15 +236,20 @@ export default function LocalizedResultsPage({
 
           {programmes.length > 0 && (
             <div className="flex flex-col gap-2 border-t border-white/10 pt-4">
-              {programmes.map((programme) => (
-                <div key={programme.id} className="flex items-center justify-between gap-4 text-sm">
-                  <span className="flex items-center gap-2 text-stone-300">
-                    <span style={{ color: GREEN }}>✓</span>
-                    {programme.nom}
-                  </span>
-                  <span className="font-bold text-stone-100">{programme.montant_affiche}</span>
-                </div>
-              ))}
+              {programmes.map((programme) => {
+                const row = getHeroRowDisplay(programme, dictionary.programTierLabels.verifier);
+                return (
+                  <div key={programme.id} className="flex items-center justify-between gap-4 text-sm">
+                    <span className="flex items-center gap-2 text-stone-300">
+                      <span style={{ color: row.iconColor }}>{row.icon}</span>
+                      {programme.nom}
+                    </span>
+                    <span className="font-bold text-stone-100" style={row.valueColor ? { color: row.valueColor } : undefined}>
+                      {row.value}
+                    </span>
+                  </div>
+                );
+              })}
             </div>
           )}
         </div>

--- a/src/lib/matching.ts
+++ b/src/lib/matching.ts
@@ -15,73 +15,99 @@ function parseRevenu(fourchette: string): number {
   return map[fourchette] ?? 50000;
 }
 
-function parseAge(fourchette: string): number {
-  const map: Record<string, number> = {
-    "18-30": 25,
-    "31-45": 38,
-    "46-65": 55,
-    "65+": 70,
-  };
-  return map[fourchette] ?? 40;
+// Bornes numériques réelles des tranches d'âge proposées par le questionnaire.
+// Le questionnaire ne collecte qu'une tranche, pas un âge exact : le moteur doit
+// comparer cet intervalle aux bornes age_min/age_max des programmes plutôt que de
+// réduire la tranche à un âge fictif représentatif (voir issue #58).
+const AGE_BUCKETS: Record<string, { min: number; max: number }> = {
+  "18-30": { min: 18, max: 30 },
+  "31-45": { min: 31, max: 45 },
+  "46-65": { min: 46, max: 65 },
+  "65+": { min: 65, max: Infinity },
+};
+
+type AgeEligibilite = "admissible" | "exclu" | "incertain";
+
+function evaluerAge(fourchette: string, criteres: Programme["criteres"]): AgeEligibilite {
+  const { age_min, age_max } = criteres;
+  if (age_min === undefined && age_max === undefined) return "admissible";
+
+  const intervalle = AGE_BUCKETS[fourchette];
+  // Tranche inconnue/non répondue : ne jamais transformer l'absence d'info en
+  // admissibilité ou exclusion certaine.
+  if (!intervalle) return "incertain";
+
+  if (age_min !== undefined && intervalle.max < age_min) return "exclu";
+  if (age_max !== undefined && intervalle.min > age_max) return "exclu";
+
+  const chevauche =
+    (age_min !== undefined && intervalle.min < age_min) ||
+    (age_max !== undefined && intervalle.max > age_max);
+
+  return chevauche ? "incertain" : "admissible";
 }
 
 export function trouverProgrammes(reponses: ReponseQuestionnaire): Programme[] {
   const revenu = parseRevenu(reponses.revenu);
-  const age = parseAge(reponses.age);
 
-  return programmes.filter((p) => {
-    const c = p.criteres;
+  return programmes
+    .filter((p) => {
+      const c = p.criteres;
 
-    // Province
-    if (c.provinces && !c.provinces.includes(reponses.province)) return false;
+      // Province
+      if (c.provinces && !c.provinces.includes(reponses.province)) return false;
 
-    // Propriétaire/locataire
-    if (c.proprietaire === true && reponses.statut_logement !== "proprietaire") return false;
-    if (c.locataire === true && reponses.statut_logement !== "locataire") return false;
+      // Propriétaire/locataire
+      if (c.proprietaire === true && reponses.statut_logement !== "proprietaire") return false;
+      if (c.locataire === true && reponses.statut_logement !== "locataire") return false;
 
-    // Enfants
-    if (c.enfants === true && !reponses.enfants) return false;
+      // Enfants
+      if (c.enfants === true && !reponses.enfants) return false;
 
-    // Revenu max
-    if (c.revenu_max !== undefined && revenu > c.revenu_max) return false;
+      // Revenu max
+      if (c.revenu_max !== undefined && revenu > c.revenu_max) return false;
 
-    // Revenu min
-    if (c.revenu_min !== undefined && revenu < c.revenu_min) return false;
+      // Revenu min
+      if (c.revenu_min !== undefined && revenu < c.revenu_min) return false;
 
-    // Véhicule électrique
-    if (
-      c.vehicule_elec === true &&
-      reponses.vehicule_elec !== "oui" &&
-      reponses.vehicule_elec !== "prevu"
-    ) return false;
+      // Véhicule électrique
+      if (
+        c.vehicule_elec === true &&
+        reponses.vehicule_elec !== "oui" &&
+        reponses.vehicule_elec !== "prevu"
+      ) return false;
 
-    // Rénovation
-    if (c.renovation === true && !reponses.renovation) return false;
+      // Rénovation
+      if (c.renovation === true && !reponses.renovation) return false;
 
-    // Retraite
-    if (c.retraite === true && !reponses.retraite) return false;
+      // Retraite
+      if (c.retraite === true && !reponses.retraite) return false;
 
-    // Âge min
-    if (c.age_min !== undefined && age < c.age_min) return false;
+      // Âge : seule une exclusion certaine (toute la tranche hors borne) retire
+      // le programme des résultats. Un chevauchement reste affiché mais incertain.
+      if (evaluerAge(reponses.age, c) === "exclu") return false;
 
-    // Âge max
-    if (c.age_max !== undefined && age > c.age_max) return false;
+      // Étudiant
+      if (c.etudiant === true && !reponses.etudiant) return false;
 
-    // Étudiant
-    if (c.etudiant === true && !reponses.etudiant) return false;
-
-    return true;
-  });
+      return true;
+    })
+    .map((p) => {
+      if (evaluerAge(reponses.age, p.criteres) !== "incertain") return p;
+      return { ...p, admissibiliteAgeIncertaine: true };
+    });
 }
 
 export function calculerTotal(programmes: Programme[]): { min: number; max: number } {
-  return programmes.filter((programme) => programme.montant_sommable !== false).reduce(
-    (acc, p) => ({
-      min: acc.min + p.montant_min,
-      max: acc.max + p.montant_max,
-    }),
-    { min: 0, max: 0 }
-  );
+  return programmes
+    .filter((programme) => programme.montant_sommable !== false && !programme.admissibiliteAgeIncertaine)
+    .reduce(
+      (acc, p) => ({
+        min: acc.min + p.montant_min,
+        max: acc.max + p.montant_max,
+      }),
+      { min: 0, max: 0 }
+    );
 }
 
 export function formaterArgent(montant: number, locale: Locale = "fr"): string {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -20,6 +20,12 @@ export interface Programme {
   montant_affiche: string; // ex: "Jusqu'à 10 000 $" ou "500 $ – 10 000 $"
   montant_sommable?: boolean;
   preselection_only?: boolean;
+  /**
+   * Computed by trouverProgrammes(), not stored in the catalogue: true when the
+   * user's age bucket overlaps an age_min/age_max boundary so eligibility cannot
+   * be determined from the questionnaire alone (see issue #58).
+   */
+  admissibiliteAgeIncertaine?: boolean;
   description: string;
   conditions: string[];
   lien_officiel: string;

--- a/tests/programmes-matching.test.mjs
+++ b/tests/programmes-matching.test.mjs
@@ -149,7 +149,7 @@ const resultsPageModule = loadSourceModule(join(rootDir, "src", "components", "L
   },
 });
 
-const { getConfidenceTier, sortProgrammesForTopPistes } = resultsPageModule;
+const { getConfidenceTier, getHeroRowDisplay, getProgrammeReason, sortProgrammesForTopPistes } = resultsPageModule;
 
 test("programmes.json catalogue structure is valid", () => {
   const programmes = loadProgrammesJson();
@@ -308,6 +308,33 @@ test("calculerTotal excludes programmes whose age eligibility is uncertain, even
     totalWithout,
     "an age-uncertain programme's montant must not inflate the presented total",
   );
+});
+
+test("getHeroRowDisplay does not present an age-uncertain programme as a confirmed amount (issue #58, PR #59 review)", () => {
+  const verifierLabel = "À vérifier";
+
+  const uncertain = getHeroRowDisplay({ montant_affiche: "Jusqu'à 6 000 $", admissibiliteAgeIncertaine: true }, verifierLabel);
+  assert.equal(uncertain.icon, "?");
+  assert.equal(uncertain.value, verifierLabel, "must not display the programme's montant_affiche as if it were certain");
+  assert.notEqual(uncertain.value, "Jusqu'à 6 000 $");
+
+  const certain = getHeroRowDisplay({ montant_affiche: "Jusqu'à 6 000 $", admissibiliteAgeIncertaine: false }, verifierLabel);
+  assert.equal(certain.icon, "✓");
+  assert.equal(certain.value, "Jusqu'à 6 000 $");
+});
+
+test("getProgrammeReason surfaces the age-uncertainty reason even for a preselection_only programme (issue #58, PR #59 review)", () => {
+  const rqapLikeAndAgeUncertain = {
+    preselection_only: true,
+    admissibiliteAgeIncertaine: true,
+    criteres: {},
+  };
+
+  const reasonFr = getProgrammeReason(rqapLikeAndAgeUncertain, makeAnswers(), "fr");
+  assert.match(reasonFr, /tranche d'âge/i, "the age-overlap reason must take priority over the generic preselection_only reason");
+
+  const reasonEn = getProgrammeReason(rqapLikeAndAgeUncertain, makeAnswers(), "en");
+  assert.match(reasonEn, /age range/i);
 });
 
 test("RRQ remains an orientation-only, non-summable lead", () => {

--- a/tests/programmes-matching.test.mjs
+++ b/tests/programmes-matching.test.mjs
@@ -205,17 +205,109 @@ test("trouverProgrammes matches a low-income renter", () => {
 });
 
 test("trouverProgrammes matches a retiree", () => {
-  const ids = programmeIds(trouverProgrammes(makeAnswers({
+  const matched = trouverProgrammes(makeAnswers({
     statut_logement: "proprietaire",
     revenu: "0-30000",
     retraite: true,
     age: "65+",
-  })));
+  }));
+  const ids = programmeIds(matched);
 
   assert.ok(ids.has("sre-fed"));
   assert.ok(ids.has("psv-fed"));
   assert.ok(ids.has("rrq-rentes-qc"));
   assert.ok(ids.has("credit-maintien-qc"));
+
+  // issue #58: credit-maintien-qc requires age_min 70, but "65+" also covers
+  // 65-69. The bucket is surfaced as a lead but must not be a certain match.
+  const creditMaintien = matched.find((programme) => programme.id === "credit-maintien-qc");
+  assert.equal(creditMaintien.admissibiliteAgeIncertaine, true);
+});
+
+// issue #58: age bucketing regression matrix.
+//
+// programme                     | borne réelle  | tranche   | avant (parseAge)          | après
+// credit-maintien-qc            | age_min 70    | 65+       | admissible certain (faux+) | incertain
+// rqap-assurance-parentale-qc   | age_max 50    | 46-65     | exclu certain (faux-)      | incertain, toujours visible
+// adaptation-domicile-shq       | age_min 55    | 46-65     | admissible certain (faux+) | incertain
+// aide-retour-region-bourse-qc  | age_max 40    | 31-45     | admissible certain (faux+) | incertain
+// aide-retour-region-bourse-qc  | age_max 40    | 46-65     | exclu (déjà correct)       | exclu (inchangé)
+// aide-formation-adultes-qc     | age_min 24    | 31-45     | admissible (déjà correct)  | admissible certain (inchangé)
+// aide-formation-adultes-qc     | age_min 24    | 18-30     | admissible certain (faux+) | incertain
+
+test("credit-maintien-qc (age_min 70): a 65+ user is flagged uncertain, not certainly eligible (issue #58)", () => {
+  const matched = trouverProgrammes(makeAnswers({ age: "65+", retraite: true, revenu: "0-30000" }));
+  const programme = matched.find((p) => p.id === "credit-maintien-qc");
+
+  assert.ok(programme, "credit-maintien-qc must still surface as a lead for a 65+ user");
+  assert.equal(programme.admissibiliteAgeIncertaine, true);
+});
+
+test("rqap-assurance-parentale-qc (age_max 50): a 46-65 user is no longer wrongly excluded (issue #53/#58)", () => {
+  const matchedWithOverlap = trouverProgrammes(makeAnswers({ age: "46-65", statut_logement: "locataire", enfants: true }));
+  assert.ok(
+    programmeIds(matchedWithOverlap).has("rqap-assurance-parentale-qc"),
+    "a user aged 46-50 within the 46-65 bucket must not be excluded by the representative age 55",
+  );
+
+  const rqap = matchedWithOverlap.find((p) => p.id === "rqap-assurance-parentale-qc");
+  assert.equal(rqap.admissibiliteAgeIncertaine, true);
+  // Already preselection_only/non-summable: presentation as a lead is unaffected.
+  assert.equal(rqap.preselection_only, true);
+});
+
+test("adaptation-domicile-shq (age_min 55, intermediate): 46-65 overlap is uncertain, not a certain match (issue #58)", () => {
+  const matched = trouverProgrammes(makeAnswers({ age: "46-65", statut_logement: "proprietaire", renovation: true }));
+  const programme = matched.find((p) => p.id === "adaptation-domicile-shq");
+
+  assert.ok(programme, "must still surface as a lead");
+  assert.equal(programme.admissibiliteAgeIncertaine, true);
+});
+
+test("aide-retour-region-bourse-qc (age_max 40, intermediate): overlapping, fully-eligible and fully-excluded buckets (issue #58)", () => {
+  // 31-45 overlaps the age_max 40 boundary (31-40 pass, 41-45 fail): uncertain, not a certain match.
+  const overlap = trouverProgrammes(makeAnswers({ age: "31-45", etudiant: true }));
+  const overlapProgramme = overlap.find((p) => p.id === "aide-retour-region-bourse-qc");
+  assert.ok(overlapProgramme, "must still surface as a lead for the overlapping bucket");
+  assert.equal(overlapProgramme.admissibiliteAgeIncertaine, true);
+
+  // 46-65 is entirely above 40: a certain exclusion, correctly absent from results.
+  const excluded = trouverProgrammes(makeAnswers({ age: "46-65", etudiant: true }));
+  assert.ok(
+    !programmeIds(excluded).has("aide-retour-region-bourse-qc"),
+    "a bucket entirely past the age_max boundary must remain a certain exclusion",
+  );
+});
+
+test("aide-formation-adultes-qc (age_min 24): a fully-eligible bucket stays a certain match, an overlapping bucket does not (issue #58)", () => {
+  // 31-45 is entirely above 24: a certain match, unaffected by this fix.
+  const fullyEligible = trouverProgrammes(makeAnswers({ age: "31-45", etudiant: true }));
+  const fullyEligibleProgramme = fullyEligible.find((p) => p.id === "aide-formation-adultes-qc");
+  assert.ok(fullyEligibleProgramme);
+  assert.equal(fullyEligibleProgramme.admissibiliteAgeIncertaine, undefined);
+
+  // 18-30 overlaps the age_min 24 boundary (18-23 fail, 24-30 pass): uncertain.
+  const overlap = trouverProgrammes(makeAnswers({ age: "18-30", etudiant: true }));
+  const overlapProgramme = overlap.find((p) => p.id === "aide-formation-adultes-qc");
+  assert.ok(overlapProgramme, "must still surface as a lead for the overlapping bucket");
+  assert.equal(overlapProgramme.admissibiliteAgeIncertaine, true);
+});
+
+test("calculerTotal excludes programmes whose age eligibility is uncertain, even when montant_sommable is not false (issue #58)", () => {
+  const matched = trouverProgrammes(makeAnswers({ age: "65+", retraite: true, revenu: "0-30000" }));
+  const creditMaintien = matched.find((p) => p.id === "credit-maintien-qc");
+  assert.ok(creditMaintien);
+  assert.notEqual(creditMaintien.montant_sommable, false, "precondition: this programme is summable by default");
+  assert.equal(creditMaintien.admissibiliteAgeIncertaine, true);
+
+  const totalWithout = calculerTotal(matched.filter((p) => p.id !== "credit-maintien-qc"));
+  const totalWith = calculerTotal(matched);
+
+  assert.deepEqual(
+    totalWith,
+    totalWithout,
+    "an age-uncertain programme's montant must not inflate the presented total",
+  );
 });
 
 test("RRQ remains an orientation-only, non-summable lead", () => {


### PR DESCRIPTION
## Contexte

Fixes #58 (P1 issu du re-baseline read-only #53).

Le moteur de matching (`src/lib/matching.ts`) réduisait chaque tranche d'âge collectée par le questionnaire à une seule valeur représentative fictive via `parseAge()` (`65+` → 70, `46-65` → 55, `31-45` → 38, `18-30` → 25) avant de la comparer aux bornes `age_min`/`age_max` réelles des programmes. Cela produisait des décisions d'admissibilité certaines à partir d'un âge fictif, avec des faux positifs et faux négatifs matériels (ex. `credit-maintien-qc` exige 70+, mais un utilisateur de 65-69 ans sélectionnant `65+` était présenté comme certainement admissible).

## Audit — programmes avec `age_min`/`age_max`

20 programmes possèdent une borne d'âge. La classe de défaut touche tout programme dont la borne réelle tombe strictement à l'intérieur d'une tranche du questionnaire plutôt qu'à sa frontière exacte. Matrice des cas représentatifs :

| Programme | Borne réelle | Tranche concernée | Avant (`parseAge`) | Après |
|---|---|---|---|---|
| `credit-maintien-qc` | `age_min: 70` | `65+` | admissible certain (faux positif 65-69) | **incertain** |
| `rqap-assurance-parentale-qc` | `age_max: 50` | `46-65` | exclu certain (faux négatif 46-50) | **incertain**, reste visible (déjà `preselection_only`) |
| `adaptation-domicile-shq` | `age_min: 55` | `46-65` | admissible certain (faux positif 46-54) | **incertain** |
| `aide-retour-region-bourse-qc` | `age_max: 40` | `31-45` | admissible certain (faux positif 41-45) | **incertain** |
| `aide-retour-region-bourse-qc` | `age_max: 40` | `46-65` | exclu (déjà correct) | exclu (inchangé) |
| `aide-formation-adultes-qc` | `age_min: 24` | `31-45` | admissible (déjà correct, tranche entièrement ≥24) | admissible certain (inchangé) |
| `aide-formation-adultes-qc` | `age_min: 24` | `18-30` | admissible certain (faux positif 18-23) | **incertain** |
| `sre-fed`, `psv-fed`, `montant-personnes-agees-fed`, `credit-revenus-pension-fed`, `credit-travailleurs-experience-qc`, `fractionnement-revenus-pension-fed`, `soutien-domicile-clsc-qc`, `transport-rabais-aines-munic`, `service-navette-aines-munic` | `age_min: 65` | `65+` | admissible certain | inchangé (toute la tranche ≥65) |
| (même liste) | `age_min: 65` | `46-65` | exclu (faux négatif ponctuel à 65 ans exactement) | **incertain** |
| `credit-aidant-naturel-qc`/`fed` | `age_min: 35` | `31-45` | admissible certain (faux positif 31-34) | **incertain** |
| `allocation-sv-conjoint-survivant-fed` | `age_min: 55` | `46-65` | admissible certain (faux positif 46-54) | **incertain** |
| `aide-qualification-emploi-qc` | `age_min: 25` / `age_max: 60` | `18-30` / `46-65` | déjà `preselection_only`/non-sommable | incertain explicite, présentation inchangée |
| `bourse-collegiale-munic` | `age_max: 25` | `18-30` | admissible certain (faux positif 26-30) | **incertain** |
| `rrq-rentes-qc` | `age_min: 60` | `46-65` | déjà `preselection_only`/non-sommable | incertain explicite, présentation inchangée |

## Choix de conception

Plutôt que de remplacer les valeurs représentatives 25/38/55/70 par d'autres valeurs arbitraires, chaque tranche est traitée comme un **intervalle** `[min, max]` (`18-30`, `31-45`, `46-65`, `65+`→∞) comparé aux bornes `age_min`/`age_max` :

- tranche entièrement dans la borne → admissible certain ;
- tranche entièrement hors borne → exclusion certaine (programme retiré des résultats) ;
- tranche chevauchant la borne → **incertain**, jamais transformé en admissibilité ou exclusion certaine.

Pour la présentation, le mécanisme existant d'incertitude (`preselection_only`/`montant_sommable`, palier "à vérifier") est **réutilisé** plutôt que de créer un cadre parallèle : un match dont l'âge est incertain est marqué `admissibiliteAgeIncertaine: true` (calculé à l'exécution par `trouverProgrammes()`, pas stocké dans le catalogue), ce qui :
- l'exclut de `calculerTotal()` (le montant n'est pas sommé comme certain), même si `montant_sommable` n'est pas `false` ;
- le classe en palier "à vérifier" (`getConfidenceTier`) avec un badge et une raison explicite dans l'UI existante (`ProgrammeListClient`) ;
- ne le retire jamais des résultats — l'utilisateur voit toujours la piste, cohérent avec le caractère indicatif du funnel.

Aucun changement aux tranches du questionnaire, à `questionnaire-url.ts`, ni aux URLs/états existants — l'ambiguïté est résolue uniquement côté moteur de matching.

## Fichiers modifiés

- `src/lib/matching.ts` — remplace `parseAge()` par `evaluerAge()` (comparaison d'intervalle) ; `trouverProgrammes()` ne retire un programme que sur exclusion certaine et marque les matches incertains ; `calculerTotal()` exclut les matches à âge incertain.
- `src/types/index.ts` — ajoute `Programme.admissibiliteAgeIncertaine?: boolean` (champ calculé, pas catalogué).
- `src/components/LocalizedResultsPage.tsx` — `getConfidenceTier()` classe les matches à âge incertain en palier "à vérifier" ; `getProgrammeReason()` explique l'incertitude.
- `tests/programmes-matching.test.mjs` — matrice de régression (voir ci-dessous).

## Tests ajoutés/modifiés et résultats

Ajout de 7 tests ciblés couvrant : `credit-maintien-qc` (65+ vs 70+), `rqap-assurance-parentale-qc` (46-65 vs age_max 50, ne doit plus être exclu à tort), `adaptation-domicile-shq` (age_min intermédiaire 55), `aide-retour-region-bourse-qc` (age_max intermédiaire 40 — tranche chevauchante ET tranche entièrement exclue), `aide-formation-adultes-qc` (tranche entièrement admissible ET tranche chevauchante), et l'impact sur `calculerTotal` (un programme à âge incertain n'inflate plus le total même si `montant_sommable` n'est pas `false`). Le test existant "matches a retiree" est complété d'une assertion confirmant que `credit-maintien-qc` est bien marqué incertain plutôt que silencieusement laissé tel quel.

- `npm run test:unit` → **190 pass, 0 fail** (0 avant l'installation des dépendances manquantes dans l'environnement, cf. note ci-dessous)
- `npm run check:seo` → **passed** (67 routes statiques, 29 articles de blog, dictionnaires, propagation questionnaire, etc.)
- `npm run lint` → **passed**, aucun warning
- `npm run build` → **passed** (`check:seo` puis `next build`, toutes les routes générées avec succès)
- `git diff --check` → **exit 0**, aucun problème d'espace blanc

Note d'environnement : `node_modules` était absent au démarrage de la session (aucune dépendance installée) ; `npm install` a été exécuté avant les commandes ci-dessus. Rapporté séparément des résultats produit puisque demandé par le mandat.

## Hors scope (rappel)

Finding C/D de #53, alertes de fraîcheur J-30/J-60, revalidation générale des claims financiers, refonte UX du questionnaire, refonte du catalogue de programmes au-delà des conséquences directes des bornes d'âge, mutation Search Console/Bing/GA4/Netlify — non touchés.

## CI / Deploy Preview

À observer après ouverture de la PR (Netlify Deploy Preview automatique via `netlify.toml`). Aucun déploiement manuel effectué.

## Risques résiduels

- Le champ `admissibiliteAgeIncertaine` est calculé à l'exécution (non catalogué) ; toute future modification de `trouverProgrammes()` doit continuer à le propager pour préserver l'exclusion du total.
- Les 4 tranches du questionnaire restent volontairement inchangées ; un raffinement futur des tranches (hors scope ici) réduirait davantage les cas d'ambiguïté.

---
**STOP** conformément au mandat — cette PR n'est pas mergée automatiquement ; la revue indépendante et la décision de merge reviennent au Product Owner / reviewer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017H9ydiLfr8PNMz6vAHi5dV

---
_Generated by [Claude Code](https://claude.ai/code/session_017H9ydiLfr8PNMz6vAHi5dV)_