### PR TITLE
Aligne 5 programmes de travaux physiques sur le critère renovation:true (issue #60)

### DIFF
--- a/src/data/programmes.json
+++ b/src/data/programmes.json
@@ -792,7 +792,8 @@
     "lien_officiel": "https://www.transitionenergetique.gouv.qc.ca",
     "criteres": {
       "proprietaire": true,
-      "provinces": ["QC"]
+      "provinces": ["QC"],
+      "renovation": true
     }
   },
   {
@@ -813,7 +814,8 @@
     "lien_officiel": "https://www.hydroquebec.com/residentiel/mieux-consommer",
     "criteres": {
       "proprietaire": true,
-      "provinces": ["QC"]
+      "provinces": ["QC"],
+      "renovation": true
     }
   },
   {
@@ -1411,7 +1413,8 @@
     "lien_officiel": "https://www.mamh.gouv.qc.ca",
     "criteres": {
       "proprietaire": true,
-      "provinces": ["QC"]
+      "provinces": ["QC"],
+      "renovation": true
     }
   },
   {
@@ -1432,7 +1435,8 @@
     "lien_officiel": "https://www.hydroquebec.com/residentiel/mieux-consommer",
     "criteres": {
       "proprietaire": true,
-      "provinces": ["QC"]
+      "provinces": ["QC"],
+      "renovation": true
     }
   },
   {
@@ -1471,7 +1475,8 @@
     "lien_officiel": "https://www.mamh.gouv.qc.ca",
     "criteres": {
       "proprietaire": true,
-      "provinces": ["QC"]
+      "provinces": ["QC"],
+      "renovation": true
     }
   },
   {

--- a/tests/programmes-matching.test.mjs
+++ b/tests/programmes-matching.test.mjs
@@ -555,6 +555,66 @@ test("pension income splitting range matches the already-governed fractionnement
   assert.equal(fractionnement.montant_max, 10000);
 });
 
+test("physical-work programmes require renovation:true and are excluded when the user has no renovation intent (issue #60)", () => {
+  // issue #53 re-baseline (Finding C): these 5 programmes involve physical work
+  // (isolation, appareil replacement, accessibility work, heat recovery installation,
+  // gouttière disconnection) but were missing criteres.renovation: true, so they could
+  // be matched and summed into the total even for a user who answered renovation: false.
+  const renovationGatedIds = [
+    "subv-isolation-munic",
+    "chauffe-eau-efficace-hq",
+    "accessibilite-domicile-munic",
+    "recuperateur-chaleur-hq",
+    "gouttiere-eaux-pluviales-munic",
+  ];
+
+  const programmes = loadProgrammesJson();
+  for (const id of renovationGatedIds) {
+    const programme = programmes.find((p) => p.id === id);
+    assert.ok(programme, `${id}: must still exist in the catalogue`);
+    assert.equal(programme.criteres.renovation, true, `${id}: must require criteres.renovation: true (issue #60)`);
+  }
+
+  const withoutRenovation = trouverProgrammes(makeAnswers({
+    statut_logement: "proprietaire",
+    renovation: false,
+  }));
+  const withoutRenovationIds = programmeIds(withoutRenovation);
+  for (const id of renovationGatedIds) {
+    assert.ok(
+      !withoutRenovationIds.has(id),
+      `${id}: must not be matched for a homeowner who answered renovation: false`,
+    );
+  }
+
+  const withRenovation = trouverProgrammes(makeAnswers({
+    statut_logement: "proprietaire",
+    renovation: true,
+  }));
+  const withRenovationIds = programmeIds(withRenovation);
+  for (const id of renovationGatedIds) {
+    assert.ok(
+      withRenovationIds.has(id),
+      `${id}: must still be matched for a homeowner who answered renovation: true, when other criteria are satisfied`,
+    );
+  }
+
+  // Already-correctly-scoped renovation programmes remain unchanged and unaffected.
+  const alreadyGatedIds = [
+    "renoclimat-qc",
+    "logisvert-hydro",
+    "chauffez-vert-qc",
+    "aide-securite-domicile-munic",
+    "reno-access-munic",
+  ];
+  for (const id of alreadyGatedIds) {
+    const programme = programmes.find((p) => p.id === id);
+    assert.ok(programme);
+    assert.equal(programme.criteres.renovation, true, `${id}: must remain gated by renovation (unchanged)`);
+    assert.ok(!withoutRenovationIds.has(id), `${id}: must not be matched for renovation: false`);
+  }
+});
+
 test("programmes.json catalogue size is stable and every entry has a non-empty description (issue #51)", () => {
   const programmes = loadProgrammesJson();
 


### PR DESCRIPTION
## Contexte

Suite au re-baseline post-fiabilisation #53 et au merge du P1 bucketing d'âge (#58 / PR #59), ce PR traite le **Finding C (P2)** : 5 programmes de `src/data/programmes.json` impliquant des travaux physiques n'imposaient pas `criteres.renovation: true`, contrairement à des programmes comparables déjà correctement bornés.

## Vérification des 5 programmes

Chaque programme implique bien des travaux physiques dans le ménage :

| Programme | Nature confirmée |
|---|---|
| `subv-isolation-munic` | Travaux d'isolation thermique |
| `chauffe-eau-efficace-hq` | Remplacement physique d'un chauffe-eau |
| `accessibilite-domicile-munic` | Installation de rampes/barres d'appui/élargissement de portes |
| `recuperateur-chaleur-hq` | Installation d'un récupérateur de chaleur sur la conduite de drainage |
| `gouttiere-eaux-pluviales-munic` | Travaux de débranchement des gouttières |

Comparaison avec les programmes analogues déjà bornés par `renovation: true` : `renoclimat-qc`, `logisvert-hydro`, `chauffez-vert-qc`, `aide-securite-domicile-munic`, `reno-access-munic` — tous ont la même structure `criteres` (proprietaire, provinces, renovation) que les 5 programmes corrigés.

## Correction

Ajout de `"renovation": true` dans `criteres` des 5 programmes identifiés, sans aucune autre modification (montants, descriptions, URLs, autres critères inchangés).

## Fichiers modifiés

- `src/data/programmes.json` — ajout de `criteres.renovation: true` aux 5 programmes
- `tests/programmes-matching.test.mjs` — nouveau test d'invariant groupé (issue #60)

## Tests ajoutés

Un test de groupe (plutôt que 5 duplications) verrouille :
- les 5 programmes portent bien `criteres.renovation: true` ;
- un propriétaire avec `renovation: false` ne matche aucun des 5 ;
- le même profil avec `renovation: true` matche toujours les 5 (autres critères satisfaits) ;
- les 5 programmes déjà correctement bornés (`renoclimat-qc`, etc.) restent inchangés et exclus pour `renovation: false`.

## Résultats QA

- `node --test tests/programmes-matching.test.mjs` : **28/28 pass** (incl. nouveau test issue #60)
- `npm run test:unit` : **193/193 pass**
- `npm run check:seo` : **passed** (67 static routes, 29 blog articles, etc.)
- `npm run lint` : **clean**, aucune erreur
- `npm run build` : **succès** (`check:seo` + `next build`)
- `git diff --check` : **exit 0**, aucun problème d'espace blanc

## SHA

- Départ : `origin/main` = `732cb94` (post-merge PR #59)
- Final : `95b9c02`

## État CI / Deploy Preview

À observer après ouverture de la PR (Netlify Deploy Preview + CI GitHub Actions le cas échéant). Aucun déploiement manuel effectué.

## Risques / résidus

- Aucun changement opportuniste hors scope (montants/conditions non touchés).
- Portée strictement limitée aux 5 programmes identifiés dans #53, conformément au mandat (pas de revalidation générale du catalogue).
- Le finding D (cannibalisation SEO) et autres éléments hors scope de #60 ne sont pas traités ici.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KBatrN7YpsvtTvWxHrbQLp

---
_Generated by [Claude Code](https://claude.ai/code/session_01KBatrN7YpsvtTvWxHrbQLp)_