### PR TITLE
Ajoute une alerte proactive J-30 avant les échéances de fraîcheur (issue #64)

### DIFF
--- a/docs/data-reliability-2026.md
+++ b/docs/data-reliability-2026.md
@@ -66,6 +66,16 @@ Centraliser les valeurs 2026 sensibles pour reduire les ecarts entre guides, com
 - Le registre central `src/data/finance-2026/claims-registry.mjs` relie chaque ledger de `docs/claims/` et chaque article financier sensible a son etat de gouvernance (`governed` ou `explicitly-out-of-scope`), et est recoupe automatiquement avec le systeme de fichiers par `npm run check:seo`.
 - La politique de fraicheur executable (bloquant/avertissement/exception) est implementee dans `scripts/lib/claims-freshness.mjs`, avec une horloge injectable (`ARGENTQC_FRESHNESS_NOW`) pour des tests deterministes. Voir `tests/claims-freshness.test.mjs` et `tests/finance-2026-schema.test.mjs`.
 
+### Alerte proactive de fraicheur (issue #64)
+
+- En plus du mecanisme bloquant existant (qui ne reagit qu'une fois `nextReviewAt` atteinte ou depassee), `scripts/lib/claims-freshness.mjs` expose `evaluateUpcomingReview`, qui emet un **avertissement non bloquant** des qu'une claim/surface approche de sa `nextReviewAt`.
+- Fenetre par defaut : **J-30**, centralisee dans la constante exportee `UPCOMING_REVIEW_WARNING_DAYS`. Meme fenetre pour toutes les criticites (`critical`/`high`/`medium`) : c'est une visibilite informative, pas un changement de politique de blocage.
+- `npm run check:seo` appelle cette fonction pour chaque dataset finance-2026 et chaque entree de registre gouvernee sans module dedie, et affiche le resultat dans le meme bloc `Claims freshness warnings (non-blocking, N)` que les avertissements existants (fraicheur haute/medium depassee, derive d'annee). Chaque ligne identifie la claim/surface, la date `nextReviewAt` et le nombre de jours restants.
+- Une claim non echue en dehors de la fenetre de 30 jours n'est **jamais** traitee comme `stale` ni averti : `evaluateUpcomingReview` reste silencieux tant qu'il reste plus de 30 jours.
+- Des que `nextReviewAt` est atteinte ou depassee, l'alerte proactive s'efface d'elle-meme (elle est exclusivement pre-echeance) et la politique bloquante existante (`evaluateCalendarStatus`) prend seule le relais : une claim `critical` depassee reste bloquante, une claim `high`/`medium` depassee reste un avertissement non bloquant, sans aucun changement de comportement.
+- `staleException` garde exactement sa semantique actuelle (couvre une echeance deja depassee sur une claim critique) ; elle ne doit jamais etre posee pour faire taire l'alerte proactive d'une echeance a venir normale.
+- **Reaction attendue d'un mainteneur** face a l'avertissement : planifier/effectuer la revalidation source-backed de la claim concernee avant sa `nextReviewAt`, ou documenter une `staleException` justifiee si l'echeance est reellement depassee et non regularisable immediatement. L'avertissement seul ne bloque jamais `check:seo` ni `next build`.
+
 ## Prochaine tranche recommandee
 
 1. Etendre le registre aux 17 articles actuellement `explicitly-out-of-scope`, en commencant par les plus denses (voir scopeNote de chaque entree)

--- a/scripts/check-seo.mjs
+++ b/scripts/check-seo.mjs
@@ -5,6 +5,7 @@ import {
   computeCriticalityDrift,
   computeRegistryDrift,
   evaluateCalendarStatus,
+  evaluateUpcomingReview,
   evaluateYearDrift,
   extractVersionedDatasetMetas,
   isIsoDate,
@@ -1144,8 +1145,9 @@ function checkClaimsFreshnessAndCoverage() {
   function evaluateAndCollect(label, meta) {
     const calendarResult = evaluateCalendarStatus(meta, { now });
     const yearResult = evaluateYearDrift(meta, { now });
+    const upcomingResult = evaluateUpcomingReview(meta, { now });
 
-    for (const result of [calendarResult, yearResult]) {
+    for (const result of [calendarResult, yearResult, upcomingResult]) {
       if (result.level === "blocking") {
         report(`"${label}" failed the freshness gate`, result.messages);
       } else if (result.level === "warning") {

--- a/scripts/lib/claims-freshness.mjs
+++ b/scripts/lib/claims-freshness.mjs
@@ -162,6 +162,58 @@ export function evaluateCalendarStatus(meta, { now }) {
   };
 }
 
+// Default proactive warning window (in days) before `nextReviewAt`. Applies
+// uniformly regardless of `criticality`: the point of this window is purely
+// informational visibility ahead of a deadline, not a policy change, so
+// there is no reason for a "critical" claim to get a different heads-up
+// window than a "high"/"medium" one. The blocking/overdue policy itself
+// (evaluateCalendarStatus) is untouched and still differs by criticality.
+export const UPCOMING_REVIEW_WARNING_DAYS = 30;
+
+/**
+ * Proactive, non-blocking early-warning check for a claim approaching its
+ * `nextReviewAt` (issue #64, following the read-only re-baseline #53). This
+ * is deliberately separate from evaluateCalendarStatus: that function only
+ * ever reacts once `nextReviewAt` has been reached or passed ("ok" for
+ * every day strictly before it), so it can never by itself warn ahead of
+ * time. This function only ever looks at the *upcoming* side of the same
+ * date and never reports anything once the date has arrived or passed —
+ * that is evaluateCalendarStatus's exclusive territory — so the two never
+ * disagree about the same day.
+ *
+ * `now` is always injected (ISO date string), never read from the system
+ * clock, for the same determinism reasons as the rest of this module.
+ *
+ * Returns { level: "ok" | "warning", messages: string[] }.
+ */
+export function evaluateUpcomingReview(meta, { now, windowDays = UPCOMING_REVIEW_WARNING_DAYS }) {
+  if (meta.historicalStatus === "historical-corrected") {
+    return { level: "ok", messages: [] };
+  }
+
+  // A missing/malformed nextReviewAt is already reported elsewhere
+  // (validateDatasetMetaShape as blocking, or evaluateCalendarStatus for
+  // ledger-only entries) — this proactive check has nothing useful to add.
+  if (!isIsoDate(meta.nextReviewAt)) {
+    return { level: "ok", messages: [] };
+  }
+
+  const daysRemaining = daysBetween(now, meta.nextReviewAt);
+
+  // daysRemaining < 0 means nextReviewAt is already in the past: that is
+  // overdue territory, exclusively owned by evaluateCalendarStatus.
+  if (daysRemaining < 0 || daysRemaining > windowDays) {
+    return { level: "ok", messages: [] };
+  }
+
+  return {
+    level: "warning",
+    messages: [
+      `nextReviewAt (${meta.nextReviewAt}) is coming up in ${daysRemaining} day(s) — within the ${windowDays}-day proactive freshness review window. Non-blocking: no action required until the deadline itself.`,
+    ],
+  };
+}
+
 /**
  * Non-blocking-unless-critical check that the dataset's declared `year`
  * has not fallen behind the current calendar year.

--- a/tests/claims-freshness.test.mjs
+++ b/tests/claims-freshness.test.mjs
@@ -10,9 +10,11 @@ import {
   computeCriticalityDrift,
   computeRegistryDrift,
   evaluateCalendarStatus,
+  evaluateUpcomingReview,
   evaluateYearDrift,
   extractVersionedDatasetMetas,
   isIsoDate,
+  UPCOMING_REVIEW_WARNING_DAYS,
   validateDatasetMetaShape,
   validateRegistryEntryShape,
 } from "../scripts/lib/claims-freshness.mjs";
@@ -374,6 +376,146 @@ test("the real registry has zero criticality drift against its linked finance-20
 
   const errors = computeCriticalityDrift({ registry: claimsRegistry, datasetCriticalityByModule });
   assert.deepEqual(errors, []);
+});
+
+// ── Proactive freshness early warning (issue #64) ───────────────────────────
+
+test("UPCOMING_REVIEW_WARNING_DAYS defaults to a J-30 window", () => {
+  assert.equal(UPCOMING_REVIEW_WARNING_DAYS, 30);
+});
+
+// Claim à plus de 30 jours : aucune alerte proactive.
+test("a claim more than 30 days from its nextReviewAt gets no proactive warning", () => {
+  const result = evaluateUpcomingReview({ nextReviewAt: "2026-11-30", criticality: "critical" }, { now: "2026-10-30" });
+  assert.equal(result.level, "ok");
+  assert.deepEqual(result.messages, []);
+});
+
+// Claim exactement à J-30.
+test("a claim exactly 30 days from its nextReviewAt gets a proactive warning", () => {
+  const result = evaluateUpcomingReview({ nextReviewAt: "2026-11-30", criticality: "critical" }, { now: "2026-10-31" });
+  assert.equal(result.level, "warning");
+  assert.match(result.messages[0], /30 day\(s\)/);
+});
+
+// Claim à J-1.
+test("a claim 1 day from its nextReviewAt gets a proactive warning", () => {
+  const result = evaluateUpcomingReview({ nextReviewAt: "2026-11-30", criticality: "critical" }, { now: "2026-11-29" });
+  assert.equal(result.level, "warning");
+  assert.match(result.messages[0], /1 day\(s\)/);
+});
+
+// Claim le jour de nextReviewAt : la sémantique actuelle d'evaluateCalendarStatus
+// considère ce jour comme "ok" (pas encore overdue); le warning proactif doit
+// rester cohérent avec cette même frontière (0 jour restant = encore averti,
+// jamais "overdue" tant que daysBetween(nextReviewAt, now) n'est pas > 0).
+test("a claim due exactly today (0 days remaining) still gets the proactive warning, not the overdue path", () => {
+  const meta = { nextReviewAt: "2026-11-30", criticality: "critical" };
+  const upcoming = evaluateUpcomingReview(meta, { now: "2026-11-30" });
+  assert.equal(upcoming.level, "warning");
+  assert.match(upcoming.messages[0], /0 day\(s\)/);
+
+  const calendar = evaluateCalendarStatus(meta, { now: "2026-11-30" });
+  assert.equal(calendar.level, "ok");
+});
+
+// 31 jours restants : juste hors fenêtre, aucune alerte.
+test("a claim 31 days from its nextReviewAt (just outside the window) gets no proactive warning", () => {
+  const result = evaluateUpcomingReview({ nextReviewAt: "2026-11-30", criticality: "critical" }, { now: "2026-10-30" });
+  assert.equal(result.level, "ok");
+});
+
+// Claim dépassée critique : reste bloquante, le mécanisme proactif ne
+// s'applique pas (et evaluateCalendarStatus est inchangé).
+test("an overdue critical claim gets no proactive warning and stays blocking via evaluateCalendarStatus", () => {
+  const meta = { nextReviewAt: "2026-11-30", criticality: "critical" };
+  const upcoming = evaluateUpcomingReview(meta, { now: "2026-12-01" });
+  assert.equal(upcoming.level, "ok");
+  assert.deepEqual(upcoming.messages, []);
+
+  const calendar = evaluateCalendarStatus(meta, { now: "2026-12-01" });
+  assert.equal(calendar.level, "blocking");
+});
+
+// Claim dépassée non critique : comportement actuel (warning) préservé, et
+// le mécanisme proactif n'ajoute rien pour une échéance déjà passée.
+test("an overdue non-critical claim keeps its existing warning behavior and gets no proactive warning", () => {
+  const meta = { nextReviewAt: "2026-11-30", criticality: "high" };
+  const upcoming = evaluateUpcomingReview(meta, { now: "2026-12-01" });
+  assert.equal(upcoming.level, "ok");
+
+  const calendar = evaluateCalendarStatus(meta, { now: "2026-12-01" });
+  assert.equal(calendar.level, "warning");
+});
+
+// Sortie exploitable : surface/claim (via le label composé côté check-seo.mjs),
+// date d'échéance et nombre de jours restants doivent apparaître.
+test("the proactive warning message carries the exact nextReviewAt date and days-remaining count", () => {
+  const result = evaluateUpcomingReview({ nextReviewAt: "2026-10-11", criticality: "critical" }, { now: "2026-09-21" });
+  assert.equal(result.level, "warning");
+  assert.match(result.messages[0], /2026-10-11/);
+  assert.match(result.messages[0], /20 day\(s\)/);
+  assert.match(result.messages[0], /30-day/);
+});
+
+// Un seuil de fenêtre personnalisé reste utilisable (paramètre optionnel),
+// sans changer le défaut centralisé J-30.
+test("evaluateUpcomingReview accepts a custom windowDays without changing the exported default", () => {
+  const result = evaluateUpcomingReview(
+    { nextReviewAt: "2026-11-30", criticality: "critical" },
+    { now: "2026-11-01", windowDays: 45 }
+  );
+  assert.equal(result.level, "warning");
+  assert.equal(UPCOMING_REVIEW_WARNING_DAYS, 30);
+});
+
+// historicalStatus "historical-corrected" : jamais d'alerte proactive, quelle
+// que soit la proximité de nextReviewAt (même règle que evaluateCalendarStatus).
+test("a historical-corrected claim never gets a proactive warning, however close nextReviewAt is", () => {
+  const result = evaluateUpcomingReview(
+    { nextReviewAt: "2026-09-05", criticality: "critical", historicalStatus: "historical-corrected" },
+    { now: "2026-09-04" }
+  );
+  assert.equal(result.level, "ok");
+  assert.deepEqual(result.messages, []);
+});
+
+// Missing/malformed nextReviewAt: already reported elsewhere, this proactive
+// check must not throw and must stay silent.
+test("evaluateUpcomingReview is silent (not throwing) on a missing or malformed nextReviewAt", () => {
+  assert.deepEqual(evaluateUpcomingReview({ nextReviewAt: undefined, criticality: "critical" }, { now: "2026-09-04" }), {
+    level: "ok",
+    messages: [],
+  });
+  assert.deepEqual(evaluateUpcomingReview({ nextReviewAt: "not-a-date", criticality: "critical" }, { now: "2026-09-04" }), {
+    level: "ok",
+    messages: [],
+  });
+});
+
+// Calcul stable autour des dates, sans dépendance au fuseau horaire local:
+// daysBetween (utilisé en interne) parse en UTC minuit, donc le résultat est
+// identique quel que soit process.env.TZ.
+test("evaluateUpcomingReview is a pure function of the injected now, independent of local timezone", () => {
+  const meta = { nextReviewAt: "2026-11-30", criticality: "critical" };
+  const originalTz = process.env.TZ;
+  try {
+    process.env.TZ = "Pacific/Kiritimati"; // UTC+14
+    const resultA = evaluateUpcomingReview(meta, { now: "2026-11-15" });
+    process.env.TZ = "Etc/GMT+12"; // UTC-12
+    const resultB = evaluateUpcomingReview(meta, { now: "2026-11-15" });
+    assert.deepEqual(resultA, resultB);
+    assert.equal(resultA.level, "warning");
+    assert.match(resultA.messages[0], /15 day\(s\)/);
+  } finally {
+    if (originalTz === undefined) delete process.env.TZ;
+    else process.env.TZ = originalTz;
+  }
+});
+
+test("check-seo.mjs wires evaluateUpcomingReview into its freshness gate alongside evaluateCalendarStatus", () => {
+  const source = read("scripts/check-seo.mjs");
+  assert.match(source, /evaluateUpcomingReview/);
 });
 
 test("check-seo.mjs's ARGENTQC_FRESHNESS_NOW override makes the freshness gate deterministic in CI", () => {


### PR DESCRIPTION
## Contexte

Suite au re-baseline read-only #53 et au traitement des Findings A-D (#54, #58, #60, #62), le résidu suivant est le sujet de l'issue #64 : le gate de fraîcheur existant (`scripts/lib/claims-freshness.mjs`) sait détecter une claim déjà dépassée, mais n'avertissait pas avant `nextReviewAt`.

## Préflight

- Branche de départ : `claude/issue-64-32yzh9`, créée depuis `origin/main` (SHA `1781b32`), 0 ahead/0 behind au moment du fetch.
- Worktree propre, aucun changement préexistant à préserver.

## Comportement actuel constaté

- `evaluateCalendarStatus` (scripts/lib/claims-freshness.mjs) ne réagit qu'une fois `nextReviewAt` atteinte/dépassée : `ok` tant que la date n'est pas arrivée, `warning` (non-critique dépassée) ou `blocking` (critique dépassée sans `staleException` active).
- `check:seo` n'émettait donc aucun signal avant l'échéance.

## Échéances proches observées (au moment de l'implémentation, `now` = 2026-09-04)

- `securite-vieillesse-quebec-2026` : `nextReviewAt` 2026-10-01 (27 jours)
- `supplement-revenu-garanti-2026` : `nextReviewAt` 2026-10-01 (27 jours)
- `internet-offers-2026` (src/data/finance-2026/internet-offers-2026.ts) : `nextReviewAt` 2026-10-01 (27 jours)
- `insurance-comparator-2026` (src/data/finance-2026/insurance-2026.ts) : `nextReviewAt` 2026-10-03 (29 jours)
- `assurance-emploi-2026` : `nextReviewAt` 2026-10-11 (37 jours, hors fenêtre J-30 pour l'instant)

## Règle d'alerte retenue et justification

- Nouvelle fonction pure `evaluateUpcomingReview(meta, { now, windowDays })` dans `scripts/lib/claims-freshness.mjs`, avec fenêtre par défaut centralisée et exportée : `UPCOMING_REVIEW_WARNING_DAYS = 30` (J-30), conformément à la préférence par défaut de l'issue.
- Fenêtre identique pour toutes les criticités (`critical`/`high`/`medium`) : c'est une visibilité purement informative, pas un changement de politique — pas de valeur nette identifiée à différencier par criticité pour un résidu borné, donc pas de complexité ajoutée.
- Séparation stricte des responsabilités : `evaluateUpcomingReview` ne couvre que le côté « à venir » de `nextReviewAt` (0 à `windowDays` jours restants) et redevient silencieuse (`ok`) dès que la date est atteinte ou dépassée — `evaluateCalendarStatus` reste l'unique source de vérité pour le blocage/l'avertissement post-échéance, **inchangé**.
- `historicalStatus: "historical-corrected"` reste toujours `ok`, comme pour `evaluateCalendarStatus`.
- `staleException` n'est pas touchée par ce mécanisme : elle continue de ne s'appliquer qu'aux échéances déjà dépassées côté `evaluateCalendarStatus`.
- Câblage dans `scripts/check-seo.mjs` : `evaluateAndCollect` appelle désormais `evaluateUpcomingReview` en plus de `evaluateCalendarStatus`/`evaluateYearDrift`, et ses messages `warning` rejoignent le même bloc non-bloquant `Claims freshness warnings (non-blocking, N)` affiché par `check:seo`, avec le même préfixe `label` (claim/surface) que les avertissements existants.
- Calcul déterministe : `now` toujours injecté, jamais lu de l'horloge système ; `daysBetween` interne parse en UTC minuit, donc indépendant du fuseau horaire local (couvert par un test dédié qui bascule `process.env.TZ`).

## Fichiers modifiés

- `scripts/lib/claims-freshness.mjs` : ajout de `UPCOMING_REVIEW_WARNING_DAYS` et `evaluateUpcomingReview`.
- `scripts/check-seo.mjs` : import et appel de `evaluateUpcomingReview` dans `evaluateAndCollect`.
- `tests/claims-freshness.test.mjs` : 14 nouveaux tests ciblés.
- `docs/data-reliability-2026.md` : nouvelle section « Alerte proactive de fraîcheur (issue #64) » documentant quand l'alerte apparaît, sa nature non bloquante, la politique de criticité inchangée, et la réaction attendue d'un mainteneur.

## Tests ajoutés/modifiés et résultats exacts

14 tests ajoutés dans `tests/claims-freshness.test.mjs` couvrant explicitement les scénarios demandés par l'issue :
- claim à plus de 30 jours (aucune alerte) et à exactement J-31 (hors fenêtre)
- claim exactement à J-30
- claim à J-1
- claim le jour de `nextReviewAt` (0 jour restant), avec vérification croisée que `evaluateCalendarStatus` reste `ok` ce même jour (sémantique actuelle préservée)
- claim critique dépassée : toujours `blocking` côté `evaluateCalendarStatus`, aucune alerte proactive côté `evaluateUpcomingReview`
- claim non critique dépassée : `warning` existant préservé, aucune alerte proactive
- contenu exploitable du message (date `nextReviewAt` exacte + jours restants + mention de la fenêtre 30 jours)
- fenêtre personnalisable (`windowDays`) sans changer la constante par défaut exportée
- `historical-corrected` : jamais d'alerte
- `nextReviewAt` manquant/malformé : silencieux, ne lève pas d'exception
- stabilité indépendante du fuseau horaire local (`process.env.TZ` basculé entre UTC+14 et UTC-12, résultat identique)
- câblage effectif dans `scripts/check-seo.mjs`

Résultats :
- `node --test tests/claims-freshness.test.mjs` → **44/44 pass**
- `npm run test:unit` → **207/207 pass** (les 10 échecs `ERR_MODULE_NOT_FOUND` observés initialement dans cet environnement provenaient d'un `node_modules` incomplet avant `npm ci`, confirmé pré-existant sur `main` via `git stash`, sans lien avec ce changement — résolus après `npm ci`)
- `npm run check:seo` → **passe**, avec les 4 avertissements proactifs ci-dessous
- `npm run lint` → **passe**, exit 0
- `npm run build` (`check:seo` + `next build`) → **passe**, 166 pages générées
- `git diff --check` → aucune erreur d'espace blanc

## Exemple exact de warning produit

```
Claims freshness warnings (non-blocking, 4):
- insurance-comparator-2026 (src/data/finance-2026/insurance-2026.ts): nextReviewAt (2026-10-03) is coming up in 29 day(s) — within the 30-day proactive freshness review window. Non-blocking: no action required until the deadline itself.
- internet-offers-2026 (src/data/finance-2026/internet-offers-2026.ts): nextReviewAt (2026-10-01) is coming up in 27 day(s) — within the 30-day proactive freshness review window. Non-blocking: no action required until the deadline itself.
- supplement-revenu-garanti-2026: nextReviewAt (2026-10-01) is coming up in 27 day(s) — within the 30-day proactive freshness review window. Non-blocking: no action required until the deadline itself.
- securite-vieillesse-quebec-2026: nextReviewAt (2026-10-01) is coming up in 27 day(s) — within the 30-day proactive freshness review window. Non-blocking: no action required until the deadline itself.
SEO check passed for 67 static routes, 29 blog articles, localized routes, dictionaries, questionnaire propagation, text encoding, source-backed claim ledgers, claims freshness/coverage registry, footer links, internal link usage, and the inverse SEO registry orphan gate.
```

## SHA final

`3092302aee84e0cf9c755753c31efcf64b232a1f`

## État CI/Deploy Preview

À confirmer après ouverture de la PR (Netlify Deploy Preview `READY` + SHA déployé = HEAD de la PR) — cette session va surveiller la PR et rapportera l'état une fois disponible.

## Risques ou résidus

- Aucun bump mécanique de fraîcheur ni changement financier introduit — hors périmètre respecté.
- Aucune revalidation source-backed effectuée sur SV/SRG/AE — hors périmètre respecté.
- Fenêtre unique J-30 pour toutes les criticités (pas de différenciation par criticité) : jugé suffisant pour ce résidu borné, sans complexité ajoutée non justifiée par l'issue.
- Aucun changement à `staleException`, aucune nouvelle infra (cron, notification externe) : hors périmètre respecté.

---

`CLAIMS FRESHNESS EARLY WARNING — READY FOR REVIEW`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L7wEN81aT1kNr2GZC1hRmc

---
_Generated by [Claude Code](https://claude.ai/code/session_01L7wEN81aT1kNr2GZC1hRmc)_