### PR TITLE
Corrige le bucketing du revenu dans le moteur de matching (issue #67)

### DIFF
--- a/src/components/LocalizedResultsPage.tsx
+++ b/src/components/LocalizedResultsPage.tsx
@@ -25,19 +25,22 @@ interface LocalizedResultsPageProps {
 }
 
 export function getConfidenceTier(programme: Programme): "principal" | "verifier" {
-  return programme.niveau === "municipal" || programme.preselection_only || programme.admissibiliteAgeIncertaine
+  return programme.niveau === "municipal" ||
+    programme.preselection_only ||
+    programme.admissibiliteAgeIncertaine ||
+    programme.admissibiliteRevenuIncertaine
     ? "verifier"
     : "principal";
 }
 
-// issue #58: a programme whose age eligibility is uncertain must not be
-// presented in the hero summary as a confirmed amount (calculerTotal already
+// issue #58/#67: a programme whose age or income eligibility is uncertain must not
+// be presented in the hero summary as a confirmed amount (calculerTotal already
 // excludes it from the certain total — the display must match).
 export function getHeroRowDisplay(
   programme: Programme,
   verifierLabel: string
 ): { icon: string; iconColor: string; value: string; valueColor?: string } {
-  if (programme.admissibiliteAgeIncertaine) {
+  if (programme.admissibiliteAgeIncertaine || programme.admissibiliteRevenuIncertaine) {
     return { icon: "?", iconColor: GOLD, value: verifierLabel, valueColor: GOLD };
   }
   return { icon: "✓", iconColor: GREEN, value: programme.montant_affiche };
@@ -65,6 +68,14 @@ export function getProgrammeReason(programme: Programme, reponses: ReponseQuesti
     return fr
       ? "Votre tranche d'âge chevauche le seuil d'âge de ce programme : votre admissibilité exacte reste à vérifier."
       : "Your age range overlaps this program's age threshold: your exact eligibility still needs to be verified.";
+
+  // issue #67: same principle as age ambiguity — surfaces even for
+  // preselection_only programmes, and before the generic revenu_max reason below
+  // (which assumes certain eligibility).
+  if (programme.admissibiliteRevenuIncertaine)
+    return fr
+      ? "Votre tranche de revenu chevauche le seuil de revenu de ce programme : votre admissibilité exacte reste à vérifier."
+      : "Your income range overlaps this program's income threshold: your exact eligibility still needs to be verified.";
 
   if (programme.preselection_only)
     return fr

--- a/src/lib/matching.ts
+++ b/src/lib/matching.ts
@@ -4,17 +4,6 @@ import { programmes2026 } from "@/data/finance-2026";
 
 const programmes = programmes2026 as Programme[];
 
-function parseRevenu(fourchette: string): number {
-  const map: Record<string, number> = {
-    "0-30000": 15000,
-    "30000-50000": 40000,
-    "50000-75000": 62500,
-    "75000-100000": 87500,
-    "100000+": 120000,
-  };
-  return map[fourchette] ?? 50000;
-}
-
 // Bornes numériques réelles des tranches d'âge proposées par le questionnaire.
 // Le questionnaire ne collecte qu'une tranche, pas un âge exact : le moteur doit
 // comparer cet intervalle aux bornes age_min/age_max des programmes plutôt que de
@@ -26,30 +15,57 @@ const AGE_BUCKETS: Record<string, { min: number; max: number }> = {
   "65+": { min: 65, max: Infinity },
 };
 
-type AgeEligibilite = "admissible" | "exclu" | "incertain";
+// Bornes numériques réelles des tranches de revenu proposées par le questionnaire.
+// Même principe que pour l'âge (issue #58) : le questionnaire ne collecte qu'une
+// tranche, pas un revenu exact, donc le moteur doit comparer cet intervalle aux
+// bornes revenu_min/revenu_max des programmes plutôt que de réduire la tranche à un
+// revenu fictif représentatif (voir issue #67).
+const REVENU_BUCKETS: Record<string, { min: number; max: number }> = {
+  "0-30000": { min: 0, max: 30000 },
+  "30000-50000": { min: 30000, max: 50000 },
+  "50000-75000": { min: 50000, max: 75000 },
+  "75000-100000": { min: 75000, max: 100000 },
+  "100000+": { min: 100000, max: Infinity },
+};
 
-function evaluerAge(fourchette: string, criteres: Programme["criteres"]): AgeEligibilite {
-  const { age_min, age_max } = criteres;
-  if (age_min === undefined && age_max === undefined) return "admissible";
+type Eligibilite = "admissible" | "exclu" | "incertain";
 
-  const intervalle = AGE_BUCKETS[fourchette];
+// Compare une tranche (âge ou revenu) répondue au questionnaire aux bornes min/max
+// d'un critère de programme. Partagé entre l'âge (#58) et le revenu (#67) : les deux
+// suivent exactement la même règle -- admissible si toute la tranche satisfait le
+// critère, exclu si toute la tranche y échoue, incertain si la tranche chevauche un
+// seuil ou si la tranche répondue est inconnue.
+function evaluerTranche(
+  intervalle: { min: number; max: number } | undefined,
+  seuils: { min?: number; max?: number }
+): Eligibilite {
+  if (seuils.min === undefined && seuils.max === undefined) return "admissible";
+
   // Tranche inconnue/non répondue : ne jamais transformer l'absence d'info en
   // admissibilité ou exclusion certaine.
   if (!intervalle) return "incertain";
 
-  if (age_min !== undefined && intervalle.max < age_min) return "exclu";
-  if (age_max !== undefined && intervalle.min > age_max) return "exclu";
+  if (seuils.min !== undefined && intervalle.max < seuils.min) return "exclu";
+  if (seuils.max !== undefined && intervalle.min > seuils.max) return "exclu";
 
   const chevauche =
-    (age_min !== undefined && intervalle.min < age_min) ||
-    (age_max !== undefined && intervalle.max > age_max);
+    (seuils.min !== undefined && intervalle.min < seuils.min) ||
+    (seuils.max !== undefined && intervalle.max > seuils.max);
 
   return chevauche ? "incertain" : "admissible";
 }
 
-export function trouverProgrammes(reponses: ReponseQuestionnaire): Programme[] {
-  const revenu = parseRevenu(reponses.revenu);
+function evaluerAge(fourchette: string, criteres: Programme["criteres"]): Eligibilite {
+  return evaluerTranche(AGE_BUCKETS[fourchette], { min: criteres.age_min, max: criteres.age_max });
+}
 
+// Exportée pour permettre des tests directs des seuils revenu_min/revenu_max/combinés
+// (issue #67), y compris des combinaisons qui n'existent pas encore dans le catalogue.
+export function evaluerRevenu(fourchette: string, criteres: Programme["criteres"]): Eligibilite {
+  return evaluerTranche(REVENU_BUCKETS[fourchette], { min: criteres.revenu_min, max: criteres.revenu_max });
+}
+
+export function trouverProgrammes(reponses: ReponseQuestionnaire): Programme[] {
   return programmes
     .filter((p) => {
       const c = p.criteres;
@@ -64,11 +80,10 @@ export function trouverProgrammes(reponses: ReponseQuestionnaire): Programme[] {
       // Enfants
       if (c.enfants === true && !reponses.enfants) return false;
 
-      // Revenu max
-      if (c.revenu_max !== undefined && revenu > c.revenu_max) return false;
-
-      // Revenu min
-      if (c.revenu_min !== undefined && revenu < c.revenu_min) return false;
+      // Revenu : seule une exclusion certaine (toute la tranche hors borne) retire
+      // le programme des résultats. Un chevauchement reste affiché mais incertain
+      // et n'entre pas dans le total calculé (voir issue #67).
+      if (evaluerRevenu(reponses.revenu, c) === "exclu") return false;
 
       // Véhicule électrique
       if (
@@ -93,14 +108,25 @@ export function trouverProgrammes(reponses: ReponseQuestionnaire): Programme[] {
       return true;
     })
     .map((p) => {
-      if (evaluerAge(reponses.age, p.criteres) !== "incertain") return p;
-      return { ...p, admissibiliteAgeIncertaine: true };
+      const ageIncertain = evaluerAge(reponses.age, p.criteres) === "incertain";
+      const revenuIncertain = evaluerRevenu(reponses.revenu, p.criteres) === "incertain";
+      if (!ageIncertain && !revenuIncertain) return p;
+      return {
+        ...p,
+        ...(ageIncertain ? { admissibiliteAgeIncertaine: true as const } : {}),
+        ...(revenuIncertain ? { admissibiliteRevenuIncertaine: true as const } : {}),
+      };
     });
 }
 
 export function calculerTotal(programmes: Programme[]): { min: number; max: number } {
   return programmes
-    .filter((programme) => programme.montant_sommable !== false && !programme.admissibiliteAgeIncertaine)
+    .filter(
+      (programme) =>
+        programme.montant_sommable !== false &&
+        !programme.admissibiliteAgeIncertaine &&
+        !programme.admissibiliteRevenuIncertaine
+    )
     .reduce(
       (acc, p) => ({
         min: acc.min + p.montant_min,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -26,6 +26,12 @@ export interface Programme {
    * be determined from the questionnaire alone (see issue #58).
    */
   admissibiliteAgeIncertaine?: boolean;
+  /**
+   * Computed by trouverProgrammes(), not stored in the catalogue: true when the
+   * user's income bucket overlaps a revenu_min/revenu_max boundary so eligibility
+   * cannot be determined from the questionnaire alone (see issue #67).
+   */
+  admissibiliteRevenuIncertaine?: boolean;
   description: string;
   conditions: string[];
   lien_officiel: string;

--- a/tests/programmes-matching.test.mjs
+++ b/tests/programmes-matching.test.mjs
@@ -128,7 +128,7 @@ function programmeIds(programmes) {
   return new Set(programmes.map((programme) => programme.id));
 }
 
-const { calculerTotal, trouverProgrammes } = loadSourceModule(join(rootDir, "src", "lib", "matching.ts"));
+const { calculerTotal, evaluerRevenu, trouverProgrammes } = loadSourceModule(join(rootDir, "src", "lib", "matching.ts"));
 
 const resultsPageModule = loadSourceModule(join(rootDir, "src", "components", "LocalizedResultsPage.tsx"), {
   "next/link": ({ href, children, ...props }) => React.createElement("a", { href, ...props }, children),
@@ -626,4 +626,274 @@ test("programmes.json catalogue size is stable and every entry has a non-empty d
       `${programme.id}: description must not be empty`,
     );
   }
+});
+
+// issue #67: income bucketing regression tests.
+//
+// Same root cause as issue #58 (age), but for revenu_min/revenu_max: parseRevenu()
+// used to collapse a questionnaire income bucket into a single fictitious
+// representative value (15000/40000/62500/87500/120000) before comparing it to a
+// programme's revenu_min/revenu_max. Whenever a threshold fell inside a bucket
+// rather than on its boundary, that produced a certain (and wrong) admissible or
+// excluded verdict. evaluerRevenu() now compares the bucket's real numeric interval
+// to the threshold and returns "incertain" whenever the bucket overlaps it.
+
+test("sre-fed (revenu_max 22000): the 0-30000 bucket is uncertain, not a certain match (issue #67)", () => {
+  const matched = trouverProgrammes(makeAnswers({
+    statut_logement: "proprietaire",
+    revenu: "0-30000",
+    retraite: true,
+    age: "65+",
+  }));
+  const programme = matched.find((p) => p.id === "sre-fed");
+
+  assert.ok(programme, "sre-fed must still surface as a lead for the 0-30000 bucket");
+  assert.equal(programme.admissibiliteRevenuIncertaine, true);
+});
+
+test("allocation-sv-conjoint-survivant-fed (revenu_max 28000): the 0-30000 bucket is uncertain (issue #67)", () => {
+  const matched = trouverProgrammes(makeAnswers({ revenu: "0-30000", retraite: true, age: "46-65" }));
+  const programme = matched.find((p) => p.id === "allocation-sv-conjoint-survivant-fed");
+
+  assert.ok(programme, "must still surface as a lead");
+  assert.equal(programme.admissibiliteRevenuIncertaine, true);
+});
+
+test("aide-solidarite-qc (revenu_max 15000): the 0-30000 bucket is uncertain (issue #67)", () => {
+  const matched = trouverProgrammes(makeAnswers({ revenu: "0-30000" }));
+  const programme = matched.find((p) => p.id === "aide-solidarite-qc");
+
+  assert.ok(programme, "must still surface as a lead");
+  assert.equal(programme.admissibiliteRevenuIncertaine, true);
+});
+
+test("allocation-logement-qc (revenu_max 35000): the 30000-50000 bucket is uncertain, no longer a false-negative exclusion (issue #67)", () => {
+  const matched = trouverProgrammes(makeAnswers({
+    statut_logement: "locataire",
+    revenu: "30000-50000",
+  }));
+  const ids = programmeIds(matched);
+
+  assert.ok(
+    ids.has("allocation-logement-qc"),
+    "a user earning 30 000-35 000 $ within the 30000-50000 bucket must no longer be silently excluded by the representative income of 40 000 $",
+  );
+
+  const programme = matched.find((p) => p.id === "allocation-logement-qc");
+  assert.equal(programme.admissibiliteRevenuIncertaine, true);
+});
+
+test("allocation-travailleurs-fed (revenu_max 33000): the 30000-50000 bucket is uncertain (issue #67)", () => {
+  const matched = trouverProgrammes(makeAnswers({ revenu: "30000-50000" }));
+  const programme = matched.find((p) => p.id === "allocation-travailleurs-fed");
+
+  assert.ok(programme, "must still surface as a lead");
+  assert.equal(programme.admissibiliteRevenuIncertaine, true);
+});
+
+test("a threshold exactly on a bucket boundary produces a certain verdict on both sides (issue #67)", () => {
+  // supplement-loyer-shq: revenu_max 30000, exactly the 0-30000 / 30000-50000 boundary.
+  assert.equal(
+    evaluerRevenu("0-30000", { revenu_max: 30000 }),
+    "admissible",
+    "a bucket entirely at or under the threshold must be a certain match",
+  );
+  assert.equal(
+    evaluerRevenu("30000-50000", { revenu_max: 30000 }),
+    "incertain",
+    "the adjacent bucket still overlaps the threshold and must be uncertain",
+  );
+});
+
+test("a bucket entirely under revenu_max is a certain admissible match (issue #67)", () => {
+  // allocation-logement-qc: revenu_max 35000; the 0-30000 bucket is entirely under it.
+  assert.equal(evaluerRevenu("0-30000", { revenu_max: 35000 }), "admissible");
+});
+
+test("a bucket entirely over revenu_max is a certain exclusion, and the programme is dropped from results (issue #67)", () => {
+  assert.equal(evaluerRevenu("50000-75000", { revenu_max: 22000 }), "exclu");
+
+  const matched = trouverProgrammes(makeAnswers({
+    statut_logement: "proprietaire",
+    revenu: "50000-75000",
+    retraite: true,
+    age: "65+",
+  }));
+  assert.ok(
+    !programmeIds(matched).has("sre-fed"),
+    "a bucket entirely past revenu_max must remain a certain exclusion, not just flagged uncertain",
+  );
+});
+
+test("revenu_min alone: below, straddling and above the threshold (issue #67)", () => {
+  const criteres = { revenu_min: 40000 };
+
+  assert.equal(evaluerRevenu("0-30000", criteres), "exclu", "a bucket entirely under revenu_min must be excluded");
+  assert.equal(evaluerRevenu("30000-50000", criteres), "incertain", "a bucket straddling revenu_min must be uncertain");
+  assert.equal(evaluerRevenu("50000-75000", criteres), "admissible", "a bucket entirely over revenu_min must be a certain match");
+});
+
+test("revenu_max alone: below, straddling and above the threshold (issue #67)", () => {
+  const criteres = { revenu_max: 60000 };
+
+  assert.equal(evaluerRevenu("30000-50000", criteres), "admissible", "a bucket entirely under revenu_max must be a certain match");
+  assert.equal(evaluerRevenu("50000-75000", criteres), "incertain", "a bucket straddling revenu_max must be uncertain");
+  assert.equal(evaluerRevenu("75000-100000", criteres), "exclu", "a bucket entirely over revenu_max must be excluded");
+});
+
+test("revenu_min and revenu_max combined narrow the certain-admissible window (issue #67)", () => {
+  const criteres = { revenu_min: 30000, revenu_max: 75000 };
+
+  assert.equal(evaluerRevenu("0-30000", criteres), "incertain", "straddles revenu_min");
+  assert.equal(evaluerRevenu("30000-50000", criteres), "admissible", "entirely within [revenu_min, revenu_max]");
+  assert.equal(evaluerRevenu("50000-75000", criteres), "admissible", "entirely within [revenu_min, revenu_max]");
+  assert.equal(evaluerRevenu("75000-100000", criteres), "incertain", "straddles revenu_max");
+  assert.equal(evaluerRevenu("100000+", criteres), "exclu", "entirely past revenu_max");
+});
+
+test("calculerTotal excludes programmes whose income eligibility is uncertain (issue #67)", () => {
+  const matched = trouverProgrammes(makeAnswers({
+    statut_logement: "locataire",
+    revenu: "30000-50000",
+  }));
+  const programme = matched.find((p) => p.id === "allocation-logement-qc");
+  assert.ok(programme);
+  assert.notEqual(programme.montant_sommable, false, "precondition: this programme is summable by default");
+  assert.equal(programme.admissibiliteRevenuIncertaine, true);
+
+  const totalWithout = calculerTotal(matched.filter((p) => p.id !== "allocation-logement-qc"));
+  const totalWith = calculerTotal(matched);
+
+  assert.deepEqual(
+    totalWith,
+    totalWithout,
+    "an income-uncertain programme's montant must not inflate the presented total",
+  );
+});
+
+test("age and income uncertainty coexist correctly on the same programme (issue #67)", () => {
+  // sre-fed: age_min 65, revenu_max 22000. A "65+" / "0-30000" profile overlaps
+  // both boundaries at once.
+  const matched = trouverProgrammes(makeAnswers({
+    statut_logement: "proprietaire",
+    revenu: "0-30000",
+    retraite: true,
+    age: "65+",
+  }));
+  const programme = matched.find((p) => p.id === "sre-fed");
+
+  assert.ok(programme, "must still surface as a lead");
+  assert.equal(programme.admissibiliteAgeIncertaine, undefined, "sre-fed age_min 65 does not overlap the 65+ bucket");
+  assert.equal(programme.admissibiliteRevenuIncertaine, true);
+
+  const total = calculerTotal(matched);
+  const totalWithoutSre = calculerTotal(matched.filter((p) => p.id !== "sre-fed"));
+  assert.deepEqual(total, totalWithoutSre, "sre-fed must not be summed while income-uncertain");
+});
+
+test("revenu bucketing regression matrix: internal thresholds stay uncertain, not silently certain (issue #67, protects #66's 19 findings)", () => {
+  const programmes = loadProgrammesJson();
+
+  // Bucket in which each programme's revenu_max threshold falls strictly inside
+  // (not on a bucket boundary). Issue #66 identified 19 such thresholds across the
+  // catalogue; a future programme added with an internal threshold must also be
+  // added here and must fail if it silently regresses to a certain verdict.
+  const internalThresholds = {
+    "sre-fed": "0-30000",
+    "aide-solidarite-qc": "0-30000",
+    "allocation-logement-qc": "30000-50000",
+    "aide-urgence-logement-qc": "0-30000",
+    "hlm-logement-social-qc": "0-30000",
+    "renoregion-shq": "30000-50000",
+    "prafr-shq": "0-30000",
+    "allocation-travailleurs-fed": "30000-50000",
+    "credit-aidant-naturel-qc": "50000-75000",
+    "credit-aidant-naturel-fed": "50000-75000",
+    "aide-premier-achat-municipal-qc": "75000-100000",
+    "allocation-sv-conjoint-survivant-fed": "0-30000",
+    "aide-energie-faible-revenu-hq": "30000-50000",
+    "acces-loisirs-qc": "30000-50000",
+    "aide-alimentaire-scolaire-qc": "30000-50000",
+    "bourse-recherche-grad-fed": "50000-75000",
+    "cooperative-habitation-qc": "50000-75000",
+    "aide-locataire-munic": "30000-50000",
+    "programme-objectif-emploi-qc": "0-30000",
+  };
+
+  assert.equal(
+    Object.keys(internalThresholds).length,
+    19,
+    "regression matrix must cover exactly the 19 internal thresholds identified by issue #66",
+  );
+
+  for (const [id, tranche] of Object.entries(internalThresholds)) {
+    const programme = programmes.find((p) => p.id === id);
+    assert.ok(programme, `${id}: must exist in the catalogue`);
+    assert.equal(
+      evaluerRevenu(tranche, programme.criteres),
+      "incertain",
+      `${id}: tranche ${tranche} overlaps revenu_max=${programme.criteres.revenu_max} and must be uncertain, not a certain match`,
+    );
+  }
+
+  // The remaining catalogue thresholds sit exactly on a bucket boundary: the
+  // bucket below is a certain match, the bucket above overlaps and is uncertain.
+  const boundaryThresholds = {
+    "supplement-loyer-shq": { below: "0-30000", above: "30000-50000" },
+    "tarif-reduit-transport-munic": { below: "0-30000", above: "30000-50000" },
+    "subvention-canadienne-etudes-fed": { below: "30000-50000", above: "50000-75000" },
+    "prog-regional-hab-qc": { below: "30000-50000", above: "50000-75000" },
+  };
+
+  for (const [id, { below, above }] of Object.entries(boundaryThresholds)) {
+    const programme = programmes.find((p) => p.id === id);
+    assert.ok(programme, `${id}: must exist in the catalogue`);
+    assert.equal(
+      evaluerRevenu(below, programme.criteres),
+      "admissible",
+      `${id}: tranche ${below} sits entirely under revenu_max=${programme.criteres.revenu_max} and must be a certain match`,
+    );
+    assert.equal(
+      evaluerRevenu(above, programme.criteres),
+      "incertain",
+      `${id}: tranche ${above} overlaps revenu_max=${programme.criteres.revenu_max} and must be uncertain`,
+    );
+  }
+
+  const withRevenu = programmes.filter(
+    (p) => p.criteres.revenu_min !== undefined || p.criteres.revenu_max !== undefined,
+  );
+  assert.equal(
+    withRevenu.length,
+    Object.keys(internalThresholds).length + Object.keys(boundaryThresholds).length,
+    "unexpected number of programmes with a revenu criterion -- update this regression matrix deliberately if programmes were added/removed",
+  );
+});
+
+test("getHeroRowDisplay does not present an income-uncertain programme as a confirmed amount (issue #67)", () => {
+  const verifierLabel = "À vérifier";
+
+  const uncertain = getHeroRowDisplay({ montant_affiche: "Jusqu'à 1 000 $", admissibiliteRevenuIncertaine: true }, verifierLabel);
+  assert.equal(uncertain.icon, "?");
+  assert.equal(uncertain.value, verifierLabel);
+  assert.notEqual(uncertain.value, "Jusqu'à 1 000 $");
+});
+
+test("getConfidenceTier demotes an income-uncertain programme to verifier (issue #67)", () => {
+  assert.equal(getConfidenceTier({ niveau: "federal", admissibiliteRevenuIncertaine: true }), "verifier");
+  assert.equal(getConfidenceTier({ niveau: "federal", admissibiliteRevenuIncertaine: false }), "principal");
+});
+
+test("getProgrammeReason surfaces the income-uncertainty reason, including for preselection_only programmes (issue #67)", () => {
+  const revenuUncertain = {
+    preselection_only: true,
+    admissibiliteRevenuIncertaine: true,
+    criteres: {},
+  };
+
+  const reasonFr = getProgrammeReason(revenuUncertain, makeAnswers(), "fr");
+  assert.match(reasonFr, /tranche de revenu/i, "the income-overlap reason must take priority over the generic preselection_only reason");
+
+  const reasonEn = getProgrammeReason(revenuUncertain, makeAnswers(), "en");
+  assert.match(reasonEn, /income range/i);
 });


### PR DESCRIPTION
## Contexte

Closes #67. Suite à la re-baseline read-only #66 (Finding 1 P1, confirmé indépendamment sur `main`).

Le questionnaire collecte le revenu par fourchettes larges, mais `src/lib/matching.ts::parseRevenu()` transformait chaque fourchette en une valeur représentative unique (`15000`, `40000`, `62500`, `87500`, `120000`) avant de la comparer aux critères `revenu_min`/`revenu_max`. Cela produisait des faux positifs/négatifs certains dès qu'un seuil de programme tombait à l'intérieur d'une tranche — même défaut que le bucketing d'âge corrigé en #58/#59.

## Ce qui change

- `parseRevenu()` est supprimée. `REVENU_BUCKETS` définit les bornes numériques réelles des 5 tranches du questionnaire (miroir de `AGE_BUCKETS`).
- Nouvelle fonction générique `evaluerTranche(intervalle, seuils)`, partagée par l'âge et le revenu : admissible si toute la tranche satisfait le seuil, exclu si toute la tranche y échoue, incertain si chevauchement ou tranche inconnue. Évite de dupliquer la logique âge/revenu (mandat, point 6).
- `evaluerAge()` et `evaluerRevenu()` (exportée pour tests directs) délèguent à `evaluerTranche()`, gérant `revenu_min`/`revenu_max` seuls ou combinés.
- `trouverProgrammes()` : un programme n'est retiré des résultats que si `evaluerRevenu(...) === "exclu"` (exclusion certaine). Un chevauchement reçoit `admissibiliteRevenuIncertaine: true` (nouveau champ calculé, jamais stocké dans le catalogue), pouvant coexister avec `admissibiliteAgeIncertaine`.
- `calculerTotal()` exclut désormais aussi les programmes `admissibiliteRevenuIncertaine`.
- UI (`LocalizedResultsPage.tsx`) : un programme revenu-incertain passe en tier "à vérifier", affiche `?` + "À vérifier" au lieu du montant confirmé, avec une raison explicite — cohérent avec le traitement existant de l'incertitude d'âge, y compris pour les programmes `preselection_only`.

## Fichiers modifiés

- `src/lib/matching.ts`
- `src/types/index.ts` (ajout `admissibiliteRevenuIncertaine?: boolean`)
- `src/components/LocalizedResultsPage.tsx`
- `tests/programmes-matching.test.mjs`

## Tests ajoutés

- Faux positif confirmé `sre-fed` / `0-30000` → incertain.
- `allocation-sv-conjoint-survivant-fed` → incertain.
- `aide-solidarite-qc` / `0-30000` → incertain.
- Faux négatif confirmé `allocation-logement-qc` / `30000-50000` → incertain, reste visible.
- `allocation-travailleurs-fed` → incertain.
- Seuil exactement sur une frontière de tranche → comportement certain correct des deux côtés.
- Tranche entièrement admissible / entièrement exclue (avec retrait effectif des résultats).
- `revenu_min` seul, `revenu_max` seul, combinaison des deux.
- Exclusion du total calculé pour un programme revenu-incertain.
- Coexistence correcte des incertitudes âge + revenu (`sre-fed`, 65+ / 0-30000).
- Table de régression dédiée protégeant les **19 seuils internes** identifiés par l'audit #66, plus les 4 seuils exactement sur une frontière, avec assertion sur le nombre total de programmes `revenu_min`/`revenu_max` du catalogue (23) pour détecter tout ajout futur non couvert.
- Non-régression UI : `getHeroRowDisplay`, `getConfidenceTier`, `getProgrammeReason`.

## Validation

- `npm run test:unit` : **224/224 passent** (207 avant cette PR, aucune régression, notamment sur la matrice âge #58).
- `npm run check:seo` : **passe** (4 avertissements de fraîcheur non bloquants, préexistants, sans rapport avec cette PR).
- `npm run lint` : **passe**, aucun avertissement.
- `npm run build` : **passe**.
- Validation manuelle en production locale (`npm run start`) : `/fr/resultats` avec un profil locataire/revenu `30000-50000` affiche bien `Allocation-logement (Québec)` avec l'icône `?` et "À vérifier" au lieu du montant confirmé.

## Hors scope (non traité, conforme au mandat)

- Modification des seuils financiers eux-mêmes.
- Modification des fourchettes du questionnaire.
- Finding 2 de #66 (pages SEO dupliquées).
- Refactor global du catalogue ou de l'architecture SEO.

Rapport de complétion détaillé également publié en commentaire sur #67.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M3WFuqfHJKVgsAWsFSxZAo

---
_Generated by [Claude Code](https://claude.ai/code/session_01M3WFuqfHJKVgsAWsFSxZAo)_