### PR TITLE
Centraliser 7/7 pages SEO sur getProgrammeFromCatalogue() (issue #86)

### DIFF
--- a/docs/data-reliability-2026.md
+++ b/docs/data-reliability-2026.md
@@ -78,6 +78,6 @@ Centraliser les valeurs 2026 sensibles pour reduire les ecarts entre guides, com
 
 ## Prochaine tranche recommandee
 
-1. Etendre le registre aux 17 articles actuellement `explicitly-out-of-scope`, en commencant par les plus denses (voir scopeNote de chaque entree)
+1. Le registre est complet a **30 governed / 0 explicitly-out-of-scope** (re-baseline issue #85) ; aucun article restant a etendre sur cet axe
 2. Revalider humainement `tax-2026.ts`, `internet-offers-2026.ts`, `insurance-2026.ts` et `programmes-2026.ts`, actuellement en avertissement de fraicheur non bloquant
 3. Remplacer progressivement les chiffres sensibles restants dans `src/app/*/page.tsx`

--- a/src/app/aide-famille-quebec/page.tsx
+++ b/src/app/aide-famille-quebec/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import SeoProgrammesPage from "@/components/SeoProgrammesPage";
+import { getProgrammeFromCatalogue } from "@/data/finance-2026";
 import type { Programme } from "@/types";
 
 export const metadata: Metadata = {
@@ -11,70 +12,10 @@ export const metadata: Metadata = {
 };
 
 const programmes: Programme[] = [
-  {
-    id: "irapvf-qc",
-    nom: "Allocation famille (Québec)",
-    organisme: "Retraite Québec",
-    niveau: "provincial",
-    categorie: "famille",
-    montant_min: 0,
-    montant_max: 3068,
-    montant_affiche: "Jusqu'à 3 068 $ par enfant en 2026 — à vérifier",
-    montant_sommable: false,
-    preselection_only: true,
-    description: "Allocation québécoise versée trimestriellement par défaut, ou mensuellement sur demande. Le montant dépend de la situation familiale et du revenu.",
-    conditions: ["Résider au Québec", "Avoir au moins un enfant de moins de 18 ans", "Être le principal responsable de l'enfant"],
-    lien_officiel: "https://www.retraitequebec.gouv.qc.ca/fr/enfants/allocation-famille/Pages/allocation-famille.aspx",
-    criteres: { enfants: true, provinces: ["QC"] },
-  },
-  {
-    id: "ace-fed",
-    nom: "Allocation canadienne pour enfants (ACE)",
-    organisme: "Gouvernement du Canada",
-    niveau: "federal",
-    categorie: "famille",
-    montant_min: 0,
-    montant_max: 8157,
-    montant_affiche: "Jusqu'à 8 157 $ par enfant de moins de 6 ans — à vérifier",
-    montant_sommable: false,
-    preselection_only: true,
-    description: "Paiement mensuel non imposable basé sur le RFNR 2025. Une demande à l'ARC est requise; produire les déclarations maintient le calcul à jour.",
-    conditions: ["Avoir au moins un enfant de moins de 18 ans", "Résider au Canada", "Être le principal responsable des soins de l'enfant"],
-    lien_officiel: "https://www.canada.ca/fr/agence-revenu/services/prestations-enfants-familles/allocation-canadienne-enfants-apercu.html",
-    criteres: { enfants: true },
-  },
-  {
-    id: "credit-loyer-qc",
-    nom: "Crédit d'impôt pour solidarité",
-    organisme: "Revenu Québec",
-    niveau: "provincial",
-    categorie: "credits_impot",
-    montant_min: 0,
-    montant_max: 0,
-    montant_affiche: "Montant déterminé par Revenu Québec — à vérifier",
-    montant_sommable: false,
-    preselection_only: true,
-    description: "Crédit d'impôt remboursable pour les ménages à revenus faibles ou modestes, combinant jusqu'à trois composantes selon le dossier. Montant et fréquence de versement déterminés par Revenu Québec.",
-    conditions: ["Résider au Québec au 31 décembre 2025", "Produire la déclaration de revenus 2025 et l'annexe D si le logement s'applique", "Faire vérifier le montant par Revenu Québec"],
-    lien_officiel: "https://www.revenuquebec.ca/fr/citoyens/credits-dimpot/credit-dimpot-pour-solidarite/",
-    criteres: { provinces: ["QC"] },
-  },
-  {
-    id: "credit-tps-fed",
-    nom: "Allocation canadienne pour l’épicerie et les besoins essentiels (ACEBE)",
-    organisme: "Gouvernement du Canada",
-    niveau: "federal",
-    categorie: "credits_impot",
-    montant_min: 0,
-    montant_max: 0,
-    montant_affiche: "Montant calculé par l’ARC — à vérifier",
-    montant_sommable: false,
-    preselection_only: true,
-    description: "Prestation trimestrielle non imposable calculée selon le revenu familial net rajusté de 2025 et la composition familiale.",
-    conditions: ["Résider au Canada", "Produire une déclaration de revenus", "Faire vérifier le montant par l’ARC"],
-    lien_officiel: "https://www.canada.ca/fr/agence-revenu/services/prestations-enfants-familles/allocation-canadienne-epicerie-besoins-essentiels.html",
-    criteres: {},
-  },
+  getProgrammeFromCatalogue("irapvf-qc"),
+  getProgrammeFromCatalogue("ace-fed"),
+  getProgrammeFromCatalogue("credit-loyer-qc"),
+  getProgrammeFromCatalogue("credit-tps-fed"),
 ];
 
 const faqs = [

--- a/src/app/aide-lunettes-quebec/page.tsx
+++ b/src/app/aide-lunettes-quebec/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import SeoProgrammesPage from "@/components/SeoProgrammesPage";
+import { getProgrammeFromCatalogue } from "@/data/finance-2026";
 import type { Programme } from "@/types";
 
 export const metadata: Metadata = {
@@ -10,6 +11,14 @@ export const metadata: Metadata = {
 };
 
 const programmes: Programme[] = [
+  // frais-medicaux-fed and frais-medicaux-qc have no catalogue counterpart
+  // that represents the same claim: the closest catalogue entry
+  // (credit-frais-medicaux-qc, a flat 50 $–400 $ range) frames the Québec
+  // medical-expense credit differently from this page's rate-based
+  // presentation (up to 20% of expenses, up to 1 500 $) and is not a
+  // mechanical rename — reconciling it would mean revalidating which claim
+  // is correct, out of scope for issue #86 (see the durable report on
+  // issue #86 for the residual P2 finding and recommended follow-up).
   {
     id: "frais-medicaux-fed",
     nom: "Crédit d'impôt pour frais médicaux",
@@ -48,26 +57,11 @@ const programmes: Programme[] = [
     lien_officiel: "https://www.revenuquebec.ca/fr/citoyens/credits-dimpot/credit-dimpot-pour-frais-medicaux/",
     criteres: { provinces: ["QC"] },
   },
-  {
-    id: "credit-solidarite-sante",
-    nom: "Crédit d'impôt pour solidarité",
-    organisme: "Revenu Québec",
-    niveau: "provincial",
-    categorie: "credits_impot",
-    montant_min: 0,
-    montant_max: 0,
-    montant_affiche: "Montant déterminé par Revenu Québec — à vérifier",
-    montant_sommable: false,
-    preselection_only: true,
-    description: "Crédit remboursable pour les ménages à revenus modestes. Bien qu'il ne couvre pas directement les lunettes, il peut augmenter le revenu disponible pour ces dépenses.",
-    conditions: [
-      "Résider au Québec au 31 décembre 2025",
-      "Produire la déclaration de revenus 2025",
-      "Faire vérifier le montant par Revenu Québec"
-    ],
-    lien_officiel: "https://www.revenuquebec.ca/fr/citoyens/credits-dimpot/credit-dimpot-pour-solidarite/",
-    criteres: { provinces: ["QC"] },
-  },
+  // credit-solidarite-sante was a page-local alias for the same governed
+  // program as credit-loyer-qc (Crédit d'impôt pour solidarité), already
+  // at 0 $/0 $ "à vérifier" on both sides — a safe id consolidation, not a
+  // claim change (issue #86).
+  getProgrammeFromCatalogue("credit-loyer-qc"),
 ];
 
 const faqs = [

--- a/src/app/allocation-enfant-quebec/page.tsx
+++ b/src/app/allocation-enfant-quebec/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import SeoProgrammesPage from "@/components/SeoProgrammesPage";
+import { getProgrammeFromCatalogue } from "@/data/finance-2026";
 import type { Programme } from "@/types";
 
 export const metadata: Metadata = {
@@ -11,38 +12,8 @@ export const metadata: Metadata = {
 };
 
 const programmes: Programme[] = [
-  {
-    id: "irapvf-qc",
-    nom: "Allocation famille (Québec)",
-    organisme: "Retraite Québec",
-    niveau: "provincial",
-    categorie: "famille",
-    montant_min: 0,
-    montant_max: 3068,
-    montant_affiche: "Jusqu'à 3 068 $ par enfant en 2026 — à vérifier",
-    montant_sommable: false,
-    preselection_only: true,
-    description: "Allocation québécoise calculée selon la situation familiale et le revenu. Elle est versée trimestriellement par défaut, ou mensuellement sur demande.",
-    conditions: ["Résider au Québec", "Avoir au moins un enfant de moins de 18 ans", "Être le principal responsable de l'enfant"],
-    lien_officiel: "https://www.retraitequebec.gouv.qc.ca/fr/enfants/allocation-famille/Pages/allocation-famille.aspx",
-    criteres: { enfants: true, provinces: ["QC"] },
-  },
-  {
-    id: "ace-fed",
-    nom: "Allocation canadienne pour enfants (ACE)",
-    organisme: "Gouvernement du Canada",
-    niveau: "federal",
-    categorie: "famille",
-    montant_min: 0,
-    montant_max: 8157,
-    montant_affiche: "Jusqu'à 8 157 $ par enfant de moins de 6 ans — à vérifier",
-    montant_sommable: false,
-    preselection_only: true,
-    description: "Prestation mensuelle non imposable calculée selon le RFNR 2025. Une demande à l'ARC est requise; la déclaration de revenus maintient le calcul à jour.",
-    conditions: ["Avoir au moins un enfant de moins de 18 ans", "Résider au Canada", "Être le principal responsable des soins de l'enfant"],
-    lien_officiel: "https://www.canada.ca/fr/agence-revenu/services/prestations-enfants-familles/allocation-canadienne-enfants-apercu.html",
-    criteres: { enfants: true },
-  },
+  getProgrammeFromCatalogue("irapvf-qc"),
+  getProgrammeFromCatalogue("ace-fed"),
 ];
 
 const faqs = [

--- a/src/app/allocation-logement-quebec/page.tsx
+++ b/src/app/allocation-logement-quebec/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import SeoProgrammesPage from "@/components/SeoProgrammesPage";
+import { getProgrammeFromCatalogue } from "@/data/finance-2026";
 import type { Programme } from "@/types";
 
 export const metadata: Metadata = {
@@ -10,48 +11,9 @@ export const metadata: Metadata = {
 };
 
 const programmes: Programme[] = [
-  {
-    id: "allocation-logement-qc",
-    nom: "Allocation-logement (Québec)",
-    organisme: "Revenu Québec (programme de la Société d'habitation du Québec)",
-    niveau: "provincial",
-    categorie: "logement",
-    montant_min: 100,
-    montant_max: 2040,
-    montant_affiche: "100 $, 150 $ ou 170 $ par mois selon le taux d'effort",
-    description: "Aide financière mensuelle pour les locataires et propriétaires-occupants à faible revenu qui consacrent une trop grande part de leurs revenus au logement. Le montant est l'un de trois paliers fixes selon le taux d'effort au logement.",
-    conditions: ["Être locataire ou propriétaire-occupant au Québec", "Avoir 50 ans ou plus, ou avoir un enfant à charge", "Revenu et épargne sous les seuils établis (max. 50 000 $ d'épargne)"],
-    lien_officiel: "https://www.revenuquebec.ca/fr/citoyens/votre-situation/faible-revenu/programme-allocation-logement/",
-    criteres: { provinces: ["QC"], revenu_max: 46640 },
-  },
-  {
-    id: "credit-loyer-qc",
-    nom: "Crédit d'impôt pour solidarité",
-    organisme: "Revenu Québec",
-    niveau: "provincial",
-    categorie: "credits_impot",
-    montant_min: 150,
-    montant_max: 2000,
-    montant_affiche: "150 $ – 2 000 $",
-    description: "Crédit d'impôt remboursable pour les ménages à revenus faibles ou modestes, incluant une composante habitation pour les locataires et propriétaires.",
-    conditions: ["Résider au Québec au 31 décembre", "Revenu familial sous les seuils établis", "Produire une déclaration de revenus au Québec"],
-    lien_officiel: "https://www.revenuquebec.ca/fr/citoyens/credits-dimpot/credit-dimpot-pour-solidarite/",
-    criteres: { provinces: ["QC"], revenu_max: 60000 },
-  },
-  {
-    id: "aide-solidarite-qc",
-    nom: "Aide sociale",
-    organisme: "Gouvernement du Québec",
-    niveau: "provincial",
-    categorie: "logement",
-    montant_min: 700,
-    montant_max: 12000,
-    montant_affiche: "Jusqu'à 12 000 $ par année",
-    description: "Aide financière de dernier recours pour les personnes sans emploi et sans autres ressources au Québec.",
-    conditions: ["Résider au Québec", "Avoir peu ou pas de revenus et d'actifs", "Être dans une situation de besoin financier"],
-    lien_officiel: "https://www.quebec.ca/famille-et-soutien-aux-personnes/aide-sociale-et-solidarite-sociale",
-    criteres: { provinces: ["QC"], revenu_max: 15000 },
-  },
+  getProgrammeFromCatalogue("allocation-logement-qc"),
+  getProgrammeFromCatalogue("credit-loyer-qc"),
+  getProgrammeFromCatalogue("aide-solidarite-qc"),
 ];
 
 const faqs = [

--- a/src/app/chauffez-vert-quebec/page.tsx
+++ b/src/app/chauffez-vert-quebec/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import SeoProgrammesPage from "@/components/SeoProgrammesPage";
+import { getProgrammeFromCatalogue } from "@/data/finance-2026";
 import type { Programme } from "@/types";
 
 export const metadata: Metadata = {
@@ -17,47 +18,11 @@ export const metadata: Metadata = {
 };
 
 const programmes: Programme[] = [
-  {
-    id: "chauffez-vert-qc",
-    nom: "Chauffez vert — volet Passage à la biénergie électricité-gaz naturel",
-    organisme: "Gouvernement du Québec / Énergir",
-    niveau: "provincial",
-    categorie: "energie",
-    montant_min: 500,
-    montant_max: 7400,
-    montant_affiche: "Jusqu'à 7 400 $ (jusqu'à 80 % des coûts d'installation)",
-    description:
-      "Depuis le 1er avril 2026, l'aide pour convertir un chauffage central au gaz naturel en système biénergie (électricité en source principale, gaz naturel en appoint) est administrée directement par Énergir pour ses clients résidentiels. Ne s'applique pas au remplacement d'un chauffage au mazout ou au propane (volet distinct, terminé).",
-    conditions: [
-      "Être propriétaire d'une résidence chauffée au gaz naturel desservie par Énergir",
-      "Installer un système biénergie avec l'électricité comme source principale",
-      "S'inscrire directement auprès d'Énergir",
-    ],
-    lien_officiel:
-      "https://www.quebec.ca/habitation-territoire/chauffage-consommation-energie/aide-financiere-renovation-ecoenergetique/conversion-bienergie-electricite-gaz-naturel",
-    criteres: { proprietaire: true, provinces: ["QC"], renovation: true },
-  },
-  {
-    id: "logisvert-hydro-cv",
-    nom: "LogisVert – Thermopompe efficace",
-    organisme: "Hydro-Québec",
-    niveau: "provincial",
-    categorie: "energie",
-    montant_min: 500,
-    montant_max: 6700,
-    montant_affiche: "Jusqu'à 6 700 $",
-    description:
-      "Pour remplacer un chauffage au mazout ou au propane par une thermopompe, maintenant que ce volet de Chauffez vert est terminé, LogisVert d'Hydro-Québec offre jusqu'à 6 700 $ pour l'achat d'une thermopompe centrale ou de mini-splits certifiée ENERGY STAR.",
-    conditions: [
-      "Être client Hydro-Québec résidentiel",
-      "Thermopompe sur la liste des appareils reconnus par Hydro-Québec",
-      "Installation par un entrepreneur certifié RBQ",
-      "Faire la demande dans les 9 mois suivant l'installation",
-    ],
-    lien_officiel:
-      "https://www.hydroquebec.com/residentiel/mieux-consommer/conseils/fenetres-chauffage-climatisation/thermopompes/aide-financiere.html",
-    criteres: { proprietaire: true, provinces: ["QC"], renovation: true },
-  },
+  getProgrammeFromCatalogue("chauffez-vert-qc"),
+  // Catalogue id is "logisvert-hydro" (no "-cv" suffix) — same program, same
+  // Hydro-Québec amounts (500 $–6 700 $); this page previously carried its
+  // own copy under a page-local id variant (issue #86).
+  getProgrammeFromCatalogue("logisvert-hydro"),
 ];
 
 const faqs = [

--- a/src/app/credit-solidarite-quebec/page.tsx
+++ b/src/app/credit-solidarite-quebec/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import SeoProgrammesPage from "@/components/SeoProgrammesPage";
+import { getProgrammeFromCatalogue } from "@/data/finance-2026";
 import type { Programme } from "@/types";
 
 export const metadata: Metadata = {
@@ -10,48 +11,9 @@ export const metadata: Metadata = {
 };
 
 const programmes: Programme[] = [
-  {
-    id: "credit-loyer-qc",
-    nom: "Crédit d'impôt pour solidarité",
-    organisme: "Revenu Québec",
-    niveau: "provincial",
-    categorie: "credits_impot",
-    montant_min: 150,
-    montant_max: 2000,
-    montant_affiche: "150 $ – 2 000 $",
-    description: "Crédit d'impôt remboursable combinant trois composantes : TVQ, habitation et village nordique. Versé mensuellement ou annuellement selon le montant.",
-    conditions: ["Résider au Québec au 31 décembre", "Revenu familial sous les seuils établis", "Produire une déclaration de revenus au Québec"],
-    lien_officiel: "https://www.revenuquebec.ca/fr/citoyens/credits-dimpot/credit-dimpot-pour-solidarite/",
-    criteres: { provinces: ["QC"], revenu_max: 60000 },
-  },
-  {
-    id: "credit-tps-fed",
-    nom: "Crédit pour la TPS/TVH",
-    organisme: "Gouvernement du Canada",
-    niveau: "federal",
-    categorie: "credits_impot",
-    montant_min: 100,
-    montant_max: 700,
-    montant_affiche: "Jusqu'à 700 $ par année",
-    description: "Paiements trimestriels non imposables pour aider les personnes et familles à revenus faibles ou modestes à récupérer une partie de la TPS/TVH payée.",
-    conditions: ["Résider au Canada", "Produire une déclaration de revenus", "Avoir 19 ans ou plus (ou avoir un conjoint/enfant)"],
-    lien_officiel: "https://www.canada.ca/fr/agence-revenu/services/prestations-enfants-familles/credit-taxe-produits-services-taxe-vente-harmonisee-tps-tvh.html",
-    criteres: { revenu_max: 50000 },
-  },
-  {
-    id: "allocation-logement-qc",
-    nom: "Allocation-logement (Québec)",
-    organisme: "Revenu Québec (programme de la Société d'habitation du Québec)",
-    niveau: "provincial",
-    categorie: "logement",
-    montant_min: 100,
-    montant_max: 2040,
-    montant_affiche: "100 $, 150 $ ou 170 $ par mois selon le taux d'effort",
-    description: "Aide financière mensuelle pour les locataires et propriétaires-occupants à faible revenu qui consacrent une trop grande part de leurs revenus au logement.",
-    conditions: ["Être locataire ou propriétaire-occupant au Québec", "Avoir 50 ans ou plus, ou avoir un enfant à charge", "Revenu et épargne sous les seuils établis (max. 50 000 $ d'épargne)"],
-    lien_officiel: "https://www.revenuquebec.ca/fr/citoyens/votre-situation/faible-revenu/programme-allocation-logement/",
-    criteres: { provinces: ["QC"], revenu_max: 46640 },
-  },
+  getProgrammeFromCatalogue("credit-loyer-qc"),
+  getProgrammeFromCatalogue("credit-tps-fed"),
+  getProgrammeFromCatalogue("allocation-logement-qc"),
 ];
 
 const faqs = [

--- a/src/app/vehicule-electrique-quebec/page.tsx
+++ b/src/app/vehicule-electrique-quebec/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import SeoProgrammesPage from "@/components/SeoProgrammesPage";
+import { getProgrammeFromCatalogue } from "@/data/finance-2026";
 import type { Programme } from "@/types";
 
 export const metadata: Metadata = {
@@ -10,34 +11,8 @@ export const metadata: Metadata = {
 };
 
 const programmes: Programme[] = [
-  {
-    id: "subv-auto-elec-qc",
-    nom: "Roulez vert – Rabais à l'achat d'un VE",
-    organisme: "Transition énergétique Québec",
-    niveau: "provincial",
-    categorie: "transport",
-    montant_min: 500,
-    montant_max: 2000,
-    montant_affiche: "500 $ – 2 000 $",
-    description: "Rabais direct à l'achat ou à la location d'un VÉ neuf ou d'occasion. 2 000 $ pour un 100% électrique neuf, 1 000 $ pour un usage admissible. Programme valide jusqu'au 31 décembre 2026.",
-    conditions: ["Résider au Québec", "Véhicule admissible neuf ou d'occasion", "Prix de détail suggéré inférieur à 65 000 $", "Programme valide jusqu'au 31 décembre 2026"],
-    lien_officiel: "https://roulezelectrique.gouv.qc.ca/Accueil",
-    criteres: { provinces: ["QC"], vehicule_elec: true },
-  },
-  {
-    id: "subv-bornes-recharge-qc",
-    nom: "Borne de recharge à domicile – Roulez vert",
-    organisme: "Transition énergétique Québec",
-    niveau: "provincial",
-    categorie: "transport",
-    montant_min: 600,
-    montant_max: 600,
-    montant_affiche: "600 $",
-    description: "Subvention de 600 $ pour l'achat et l'installation d'une borne de recharge de niveau 2 à domicile. Cumulable avec le rabais à l'achat du VE.",
-    conditions: ["Être propriétaire ou locataire au Québec", "Posséder un véhicule électrique rechargeable", "Installation par un électricien certifié RBQ"],
-    lien_officiel: "https://roulezelectrique.gouv.qc.ca/Accueil",
-    criteres: { provinces: ["QC"], vehicule_elec: true },
-  },
+  getProgrammeFromCatalogue("subv-auto-elec-qc"),
+  getProgrammeFromCatalogue("subv-bornes-recharge-qc"),
 ];
 
 const faqs = [

--- a/tests/programme-catalogue-drift.test.mjs
+++ b/tests/programme-catalogue-drift.test.mjs
@@ -189,13 +189,19 @@ test("the real src/app tree has zero drift between local programme copies and th
   assert.deepEqual(drifts, []);
 });
 
-test("allocation-logement-quebec and credit-solidarite-quebec keep drifted copies, but only because middleware.ts permanently redirects both away before they ever render (issue #63/#66 dead code, out of scope for #69)", () => {
+test("allocation-logement-quebec and credit-solidarite-quebec (dead code, still permanently redirected by middleware.ts per issue #63/#66) now source the catalogue directly, closing the #69 exception (issue #86)", () => {
   const legacyLoyer = path.join(appDir, "allocation-logement-quebec", "page.tsx");
   const legacySolidarite = path.join(appDir, "credit-solidarite-quebec", "page.tsx");
   const middlewareSource = read(middlewareFile);
 
   assert.equal(isMiddlewareRedirectedRoute(routePathForPageFile(legacyLoyer), middlewareSource), true);
   assert.equal(isMiddlewareRedirectedRoute(routePathForPageFile(legacySolidarite), middlewareSource), true);
+
+  for (const filePath of [legacyLoyer, legacySolidarite]) {
+    const source = read(filePath);
+    assert.deepEqual(extractLocalProgrammeCopies(source), [], `${relative(filePath)} should no longer hold a local Programme[] literal to drift`);
+    assert.match(source, /getProgrammeFromCatalogue\(/);
+  }
 
   const catalogue = JSON.parse(read(programmesJsonFile));
   const drifts = findProgrammeCatalogueDrift({
@@ -205,7 +211,7 @@ test("allocation-logement-quebec and credit-solidarite-quebec keep drifted copie
     ],
     catalogue,
   });
-  assert.ok(drifts.length > 0, "expected the dead-code pages to still carry a stale credit-loyer-qc copy");
+  assert.deepEqual(drifts, []);
 });
 
 test("borne-recharge-quebec no longer hardcodes the obsolete 7 000 $ 2024 vehicle amount and sources the catalogue instead", () => {

--- a/tests/programme-catalogue-drift.test.mjs
+++ b/tests/programme-catalogue-drift.test.mjs
@@ -250,3 +250,51 @@ test("credit-impot-quebec and credit-impot-frais-medicaux-quebec no longer hardc
   assert.equal(maintien.montant_max, 10200);
   assert.equal(maintien.montant_min, 500);
 });
+
+// ── issue #86: the 5 live pages whose local text had drifted from the ──
+// governed catalogue (organisme/description/conditions/lien_officiel),
+// even though checkProgrammeCatalogueDrift's montant-only comparison saw
+// no active drift. Reconciled onto the catalogue as the single governed
+// source of truth (see the durable report on issue #86).
+
+test("allocation-enfant-quebec and aide-famille-quebec source irapvf-qc/ace-fed (and, for aide-famille-quebec, credit-loyer-qc/credit-tps-fed) from the catalogue instead of a local copy", () => {
+  const enfant = read(path.join(appDir, "allocation-enfant-quebec", "page.tsx"));
+  assert.deepEqual(extractLocalProgrammeCopies(enfant), []);
+  assert.match(enfant, /getProgrammeFromCatalogue\("irapvf-qc"\)/);
+  assert.match(enfant, /getProgrammeFromCatalogue\("ace-fed"\)/);
+
+  const famille = read(path.join(appDir, "aide-famille-quebec", "page.tsx"));
+  assert.deepEqual(extractLocalProgrammeCopies(famille), []);
+  for (const id of ["irapvf-qc", "ace-fed", "credit-loyer-qc", "credit-tps-fed"]) {
+    assert.match(famille, new RegExp(`getProgrammeFromCatalogue\\("${id}"\\)`));
+  }
+});
+
+test("chauffez-vert-quebec sources chauffez-vert-qc and consolidates its page-local logisvert-hydro-cv id onto the catalogue's logisvert-hydro", () => {
+  const source = read(path.join(appDir, "chauffez-vert-quebec", "page.tsx"));
+  assert.deepEqual(extractLocalProgrammeCopies(source), []);
+  assert.match(source, /getProgrammeFromCatalogue\("chauffez-vert-qc"\)/);
+  assert.match(source, /getProgrammeFromCatalogue\("logisvert-hydro"\)/);
+  assert.doesNotMatch(source, /logisvert-hydro-cv/);
+});
+
+test("vehicule-electrique-quebec sources subv-auto-elec-qc and subv-bornes-recharge-qc from the catalogue instead of a stale local copy (was still crediting Transition énergétique Québec, dissolved into the ministry)", () => {
+  const source = read(path.join(appDir, "vehicule-electrique-quebec", "page.tsx"));
+  assert.deepEqual(extractLocalProgrammeCopies(source), []);
+  assert.match(source, /getProgrammeFromCatalogue\("subv-auto-elec-qc"\)/);
+  assert.match(source, /getProgrammeFromCatalogue\("subv-bornes-recharge-qc"\)/);
+});
+
+test("aide-lunettes-quebec consolidates its credit-solidarite-sante alias onto the catalogue's credit-loyer-qc, but keeps frais-medicaux-fed/frais-medicaux-qc local (no catalogue entry represents the same claim without revalidating it)", () => {
+  const source = read(path.join(appDir, "aide-lunettes-quebec", "page.tsx"));
+  assert.match(source, /getProgrammeFromCatalogue\("credit-loyer-qc"\)/);
+  assert.doesNotMatch(source, /id:\s*"credit-solidarite-sante"/);
+
+  const copies = extractLocalProgrammeCopies(source);
+  const copiedIds = copies.map((copy) => copy.id).sort();
+  assert.deepEqual(copiedIds, ["frais-medicaux-fed", "frais-medicaux-qc"]);
+
+  const catalogue = JSON.parse(read(programmesJsonFile));
+  assert.equal(catalogue.find((p) => p.id === "frais-medicaux-fed"), undefined);
+  assert.equal(catalogue.find((p) => p.id === "frais-medicaux-qc"), undefined);
+});


### PR DESCRIPTION
Refs #86 — 7/7 pages centralisées ; le résidu précis `frais-medicaux-fed`/`frais-medicaux-qc` d'`aide-lunettes-quebec` est transféré vers l'issue de suivi dédiée #88.

## Résumé des changements

L'issue demandait de migrer 7 pages SEO d'un tableau `Programme[]` codé en dur vers `getProgrammeFromCatalogue()`. Une revue indépendante sur #86 a demandé de reprendre le travail après un premier commit qui ne traitait que 2/7 pages (les 2 routes mortes) : voir l'historique des commentaires de l'issue pour le contexte complet.

### Ronde 1 (commit `5be2c20`) — 2/7 pages, code mort uniquement

`allocation-logement-quebec` et `credit-solidarite-quebec` sont des routes **mortes** (`src/middleware.ts` les redirige en permanence vers `/fr/budget/...`, issue #63/#66) : migrées intégralement sans aucun risque, malgré des valeurs locales divergentes du catalogue.

### Ronde 2 (commit `51f99bd`) — reconciliation des 5 pages vivantes restantes

Pour chacune des 5 pages vivantes (`allocation-enfant-quebec`, `aide-lunettes-quebec`, `chauffez-vert-quebec`, `vehicule-electrique-quebec`, `aide-famille-quebec`), j'ai produit un diff champ par champ (organisme/description/conditions/lien_officiel) entre le `Programme[]` local et son entrée du catalogue central, puis tranché la vérité à conserver plutôt que de faire un remplacement mécanique silencieux :

- **Toutes les divergences trouvées, sauf 2 identifiants d'une seule page, étaient des reformulations ou précisions ajoutées lors d'une revalidation antérieure du catalogue** (sourceNote de `programmes-2026.ts`, issue #51/#52/#54, datée et source-backed) **jamais répercutées sur ces pages** — jamais un conflit de fait sur les montants affichés. Exemple concret : `vehicule-electrique-quebec` créditait encore l'organisme dissous « Transition énergétique Québec » alors que le catalogue a depuis « Gouvernement du Québec ».
- **Décision retenue** : adopter le catalogue comme vérité pour ces champs (c'est précisément la source gouvernée que ce chantier de centralisation vise à faire respecter) → migration complète vers `getProgrammeFromCatalogue()` pour `irapvf-qc`, `ace-fed`, `credit-loyer-qc`, `credit-tps-fed`, `chauffez-vert-qc`, `subv-auto-elec-qc`, `subv-bornes-recharge-qc`.
- **2 consolidations d'identifiants de page** vers l'id catalogue équivalent (même programme, mêmes montants, donc aucun changement de chiffre) :
  - `chauffez-vert-quebec` : `logisvert-hydro-cv` (id de page, jamais dans le catalogue) → `getProgrammeFromCatalogue("logisvert-hydro")`.
  - `aide-lunettes-quebec` : `credit-solidarite-sante` (déjà 0 $/0 $ des deux côtés, même programme que credit-loyer-qc) → `getProgrammeFromCatalogue("credit-loyer-qc")`.
- **Résidu précis et irréductible, documenté, et maintenant transféré à l'issue #88** : `aide-lunettes-quebec` garde `frais-medicaux-fed` et `frais-medicaux-qc` codés en dur. Aucune entrée du catalogue ne représente la même claim sans la revalider : la plus proche (`credit-frais-medicaux-qc`) est une fourchette fixe de 50 $–400 $, alors que cette page affiche un crédit basé sur un taux (jusqu'à 20 %, jusqu'à 1 500 $) — un vrai désaccord sur le chiffre, pas une reformulation. Trancher lequel est correct exigerait de revalider la claim, explicitement hors scope de #86 (« Ne pas revalider de claims »). **Issue de suivi dédiée : #88.**

## Fichiers modifiés (9 au total sur les 2 commits)

- `src/app/allocation-logement-quebec/page.tsx`, `src/app/credit-solidarite-quebec/page.tsx` — ronde 1.
- `src/app/allocation-enfant-quebec/page.tsx`, `src/app/aide-famille-quebec/page.tsx`, `src/app/chauffez-vert-quebec/page.tsx`, `src/app/vehicule-electrique-quebec/page.tsx`, `src/app/aide-lunettes-quebec/page.tsx` — ronde 2.
- `tests/programme-catalogue-drift.test.mjs` — tests dédiés verrouillant chaque migration/consolidation et le résidu documenté d'`aide-lunettes-quebec` (à faire évoluer par #88 une fois le catalogue corrigé).
- `docs/data-reliability-2026.md` — phrase obsolète « 17 articles `explicitly-out-of-scope` » corrigée en **30 governed / 0 explicitly-out-of-scope**.

## Résultats des tests/gates (état final, sha `51f99bd`)

- `npm run test:unit` — **250/250 passent**
- `npm run check:seo` — **passe** (67 routes statiques, 29 articles blog ; 4 avertissements de fraîcheur non bloquants préexistants, sans rapport)
- `npm run lint` — **passe**, aucune sortie
- `npm run build` — **passe**, 166 pages générées
- Deploy Preview Netlify : vert sur `51f99bd`

## Confirmation qu'aucune donnée métier/claim n'a changé

- Aucune modification de `src/data/programmes.json`, `nextReviewAt`, registre ou ledgers.
- Aucun montant affiché n'a changé nulle part (vérifié champ par champ avant chaque migration).
- Les seuls textes visibles modifiés (organisme/description/conditions/lien) alignent des pages sur une revalidation du catalogue déjà effectuée et documentée dans une issue antérieure — jamais une nouvelle claim.
- `frais-medicaux-fed`/`frais-medicaux-qc` : aucun changement, conservés tels quels précisément pour ne pas trancher une divergence financière sans revalidation.

## Findings

- **P2** — `aide-lunettes-quebec` (`frais-medicaux-fed`, `frais-medicaux-qc`) : transféré vers l'issue #88 (revalidation source-backed dédiée, puis migration finale).

## GO / NO-GO

**GO** — 7/7 pages utilisent maintenant `getProgrammeFromCatalogue()` pour la totalité de leurs entrées sauf 2 identifiants sur 1 page, dont le résidu est maintenant formellement transféré vers #88.

## Risques restants

Le résidu `frais-medicaux-fed`/`frais-medicaux-qc` reste un point de dérive latent (comme avant ce PR) tant qu'il n'est pas revalidé et ajouté au catalogue via #88 — non aggravé par ce PR, documenté et transféré explicitement au lieu d'être masqué.

## Prochaine action la plus sûre

Traiter l'issue #88 (revalidation du crédit d'impôt pour frais médicaux fédéral et québécois), puis migrer `aide-lunettes-quebec` à 100 %.

## Statut final

7/7 pages listées dans #86 centralisent maintenant leurs programmes via `getProgrammeFromCatalogue()`, à l'exception précise et documentée de 2 identifiants (`frais-medicaux-fed`, `frais-medicaux-qc`) sur `aide-lunettes-quebec`, formellement transférés vers l'issue de suivi #88.

```text
READY FOR REVIEW
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VkqwDZAhDKWVdQjMpKBU7b

---
_Generated by [Claude Code](https://claude.ai/code/session_01VkqwDZAhDKWVdQjMpKBU7b)_