### PR TITLE
Revalide les crédits d'impôt frais médicaux fédéral/QC et centralise aide-lunettes-quebec (issue #88)

### DIFF
--- a/src/app/aide-lunettes-quebec/page.tsx
+++ b/src/app/aide-lunettes-quebec/page.tsx
@@ -11,52 +11,21 @@ export const metadata: Metadata = {
 };
 
 const programmes: Programme[] = [
-  // frais-medicaux-fed and frais-medicaux-qc have no catalogue counterpart
-  // that represents the same claim: the closest catalogue entry
-  // (credit-frais-medicaux-qc, a flat 50 $–400 $ range) frames the Québec
-  // medical-expense credit differently from this page's rate-based
-  // presentation (up to 20% of expenses, up to 1 500 $) and is not a
-  // mechanical rename — reconciling it would mean revalidating which claim
-  // is correct, out of scope for issue #86 (see the durable report on
-  // issue #86 for the residual P2 finding and recommended follow-up).
-  {
-    id: "frais-medicaux-fed",
-    nom: "Crédit d'impôt pour frais médicaux",
-    organisme: "Gouvernement du Canada",
-    niveau: "federal",
-    categorie: "sante",
-    montant_min: 0,
-    montant_max: 2500,
-    montant_affiche: "15% des dépenses admissibles",
-    description: "Crédit d'impôt non remboursable de 15% sur vos frais médicaux admissibles dépassant le seuil de 3% de votre revenu net (ou 2 635 $ en 2026, selon le moins élevé). Les lunettes et verres de contact sont des dépenses admissibles.",
-    conditions: [
-      "Résider au Canada",
-      "Produire une déclaration de revenus fédérale",
-      "Conserver vos reçus de lunettes, montures, verres de contact",
-      "Dépenses dépassant 3% de votre revenu net ou 2 635 $"
-    ],
-    lien_officiel: "https://www.canada.ca/fr/agence-revenu/services/impot/particuliers/sujets/tout-votre-declaration-revenus/declaration-revenus/remplir-declaration-revenus/deductions-credits-depenses/ligne-33099-33199-depenses-admissibles-frais-medicaux.html",
-    criteres: { provinces: ["QC", "ON", "BC", "AB", "MB", "SK", "NB", "NS", "PE", "NL"] },
-  },
-  {
-    id: "frais-medicaux-qc",
-    nom: "Crédit d'impôt pour frais médicaux (Québec)",
-    organisme: "Revenu Québec",
-    niveau: "provincial",
-    categorie: "sante",
-    montant_min: 0,
-    montant_max: 1500,
-    montant_affiche: "Jusqu'à 20% des dépenses",
-    description: "Crédit d'impôt remboursable du Québec pour frais médicaux, incluant les lunettes, verres correcteurs et verres de contact prescrits. Le taux varie selon votre revenu — les ménages à faible revenu obtiennent un crédit plus élevé.",
-    conditions: [
-      "Résider au Québec",
-      "Produire une déclaration de revenus provinciale",
-      "Lunettes ou verres prescrit par un optométriste ou médecin",
-      "Conserver tous vos reçus"
-    ],
-    lien_officiel: "https://www.revenuquebec.ca/fr/citoyens/credits-dimpot/credit-dimpot-pour-frais-medicaux/",
-    criteres: { provinces: ["QC"] },
-  },
+  // frais-medicaux-fed/frais-medicaux-qc were page-local copies with no
+  // catalogue counterpart representing the same claim (issue #86 residual).
+  // Issue #88 revalidated both credits against official sources (ARC line
+  // 33099/33199; Revenu Québec ligne 381) and reconciled the real
+  // disagreement found on the Québec side: this page previously described
+  // it as a "remboursable" credit capped at 1 500 $ varying by income, but
+  // the credit that applies to eyeglasses generally is the non-refundable
+  // 20 % credit on expenses above 3 % of net family income, with no fixed
+  // dollar cap (a separate, narrower refundable credit for low-income
+  // workers exists but is out of this page's scope). Both credits now
+  // source the catalogue under credit-frais-medicaux-fed/-qc; see the
+  // durable report on issue #88 and programmes-2026.ts sourceNote for the
+  // full revalidation detail.
+  getProgrammeFromCatalogue("credit-frais-medicaux-fed"),
+  getProgrammeFromCatalogue("credit-frais-medicaux-qc"),
   // credit-solidarite-sante was a page-local alias for the same governed
   // program as credit-loyer-qc (Crédit d'impôt pour solidarité), already
   // at 0 $/0 $ "à vérifier" on both sides — a safe id consolidation, not a

--- a/src/data/finance-2026/programmes-2026.ts
+++ b/src/data/finance-2026/programmes-2026.ts
@@ -65,7 +65,32 @@ export const programmesDataset2026 = defineVersionedDataset(
       "plafond ~1 500$ indexe, reduit des 28 335$ de revenu familial net) existe reellement mais represente un " +
       "programme different de credit-frais-medicaux-qc; non ajoute au catalogue, hors mandat de l'issue #88. " +
       "aide-lunettes-quebec/page.tsx source desormais ces deux entrees via getProgrammeFromCatalogue, fermant le " +
-      "dernier residu verrouille par programme-catalogue-drift.test.mjs depuis l'issue #86.",
+      "dernier residu verrouille par programme-catalogue-drift.test.mjs depuis l'issue #86. --- " +
+      "Reponse a la revue independante NO-GO du 2026-09-05 (issue #88, 2e passe): 2 findings bloquants souleves, " +
+      "1 confirme et corrige, 1 rejete avec sources apres contre-verification independante. Finding 1 (federal 15% " +
+      "-> 14%) CONFIRME et CORRIGE: le premier taux d'imposition federal - auquel les credits non remboursables " +
+      "(dont les frais medicaux, lignes 33099/33199) sont legalement arrimes - est passe de 15% a 14,5% pour 2025 " +
+      "puis 14% pour 2026 et les annees suivantes (Ministere des Finances du Canada, Report on the Impact of " +
+      "Reducing the Lowest Marginal Personal Income Tax Rate on Non-Refundable Tax Credits, confirme egalement par " +
+      "les taux d'imposition 2026 de l'ARC et par KPMG); la revalidation du 2026-09-05 (1re passe) avait manque ce " +
+      "changement en reconduisant le taux historique de 15% sans le revalider specifiquement pour 2026. Description " +
+      "de credit-frais-medicaux-fed corrigee en consequence. Finding 2 (Quebec ligne 381, 20% -> 14%) REJETE apres " +
+      "verification: 3 sources independantes et recentes (annee d'imposition 2025), dont la page d'aide officielle " +
+      "de Revenu Quebec elle-meme pour la ligne 381, le guide specialise de la Chaire en fiscalite et en finances " +
+      "publiques de l'Universite de Sherbrooke (fiche dediee 'credit_frais_medicaux_2025_VF', datee 2025) et le " +
+      "Planiguide fiscal de Raymond Chabot Grant Thornton, confirment toutes un taux de 20% specifique a ce credit, " +
+      "sans mention d'un changement a 14%. La reforme quebecoise de 2017 qui a arrime plusieurs credits non " +
+      "remboursables usuels (montant personnel de base, credit en raison de l'age, etc.) au premier taux du bareme " +
+      "(alors 16%, aujourd'hui 14%) ne semble pas s'appliquer au credit pour frais medicaux de la ligne 381, qui " +
+      "conserve son propre taux fixe de 20% distinct de ce mecanisme - une hypothese coherente avec le fait, deja " +
+      "documente avant cette revue, que ce credit n'a pas de seuil fixe en dollars contrairement aux credits " +
+      "'arrimes au bareme'. La source citee par la revue (statistiques fiscales detaillees du ministere des " +
+      "Finances du Quebec classant 'Frais medicaux' a 14%) n'a pas pu etre recuperee directement (WebFetch " +
+      "EGRESS_BLOCKED sur budget.finances.gouv.qc.ca) ni retrouvee de maniere verifiable par recherche web; en cas " +
+      "de contradiction persistante, la page d'aide officielle Revenu Quebec de la ligne 381 elle-meme fait autorite " +
+      "et prevaut. montant_affiche/description de credit-frais-medicaux-qc INCHANGES (20% maintenu). Un acces " +
+      "reseau direct a budget.finances.gouv.qc.ca permettrait de trancher cette divergence avec certitude si elle " +
+      "est reiteree.",
     reviewCadence: "quarterly",
     nextReviewAt: "2026-12-01",
     criticality: "medium",

--- a/src/data/finance-2026/programmes-2026.ts
+++ b/src/data/finance-2026/programmes-2026.ts
@@ -19,7 +19,7 @@ export const programmesDataset2026 = defineVersionedDataset(
   "programmes-2026",
   {
     year: 2026,
-    lastUpdated: "2026-09-03",
+    lastUpdated: "2026-09-05",
     status: "editorial",
     sourceNote:
       "Revalidation source-backed reelle des claims materiels de programmes.json (issue #51, 2026-09-03): " +
@@ -41,7 +41,31 @@ export const programmesDataset2026 = defineVersionedDataset(
       "recuperateur-chaleur-hq, prafr-shq, taux exact 2026 de certains credits federaux de renovation) faute de " +
       "confirmation directe suffisante; une revalidation directe des pages officielles est recommandee des qu'un " +
       "acces reseau le permettra. Les 3 programmes a plus haut risque (credit-loyer-qc, credit-frais-garde-qc, " +
-      "credit-tps-fed) restent proteges par des guardrails dedies dans check-seo.mjs independamment de cette date.",
+      "credit-tps-fed) restent proteges par des guardrails dedies dans check-seo.mjs independamment de cette date. --- " +
+      "Revalidation du 2026-09-05 (issue #88, residu documente de l'issue #86/PR #87): ajout de l'entree federale " +
+      "credit-frais-medicaux-fed (absente du catalogue) et correction de credit-frais-medicaux-qc, jusqu'ici a " +
+      "50$-400$ - une fourchette fixe fabriquee, incompatible avec sa propre description 'sans plafond en dollars " +
+      "fixe'. WebFetch reste EGRESS_BLOCKED sur canada.ca et revenuquebec.ca (confirme de nouveau cette passe); " +
+      "verification par recherche web convergente. Federal (lignes 33099/33199, ARC): confirme taux 15% et seuil " +
+      "'le moindre de 2 834$ ou 3% du revenu net' pour l'annee d'imposition 2025 (derniere valeur publiee par " +
+      "l'ARC au moment de cette revalidation) - l'ancien texte de aide-lunettes-quebec citait '2 635$ en 2026', " +
+      "qui est en realite le seuil de l'annee d'imposition 2023 mal date; le seuil indexe 2026 n'est pas encore " +
+      "publie. URL canada.ca mise a jour vers le chemin confirme litteralement par une source qui reflete le site " +
+      "(lignes-33099-33199-frais-medicaux-admissibles-vous-pouvez-demander-votre-declaration-revenus.html), l'ancien " +
+      "chemin (ligne-33099-33199-depenses-admissibles-frais-medicaux.html) n'ayant pu etre confirme. Quebec (ligne " +
+      "381, Revenu Quebec): confirme taux 20% sur les frais excedant 3% du revenu familial net, sans seuil fixe en " +
+      "dollars (a la difference du federal) - la description existante etait deja correcte, seuls montant_min/max " +
+      "(50$-400$) la contredisaient et sont corriges a 0$/0$ selon la convention deja etablie dans ce catalogue pour " +
+      "les credits a formule non plafonnee (ex. credit-tps-fed, credit-loyer-qc: 'Montant ... - a verifier'). Fait " +
+      "specifique 2026 ajoute a la description: depuis le 2026-01-01, les frais payes aux homeopathes, " +
+      "naturopathes, osteopathes et phytotherapeutes ne sont plus admissibles au credit quebecois. URL " +
+      "revenuquebec.ca corrigee vers /fr/citoyens/credits-dimpot/frais-medicaux/ (confirmee via plusieurs resultats " +
+      "de recherche convergents), l'ancien chemin /credit-dimpot-pour-frais-medicaux/ n'ayant pu etre reconfirme. " +
+      "Un credit remboursable quebecois distinct (ligne 462 point 1, travailleurs a faible revenu, taux 25%, " +
+      "plafond ~1 500$ indexe, reduit des 28 335$ de revenu familial net) existe reellement mais represente un " +
+      "programme different de credit-frais-medicaux-qc; non ajoute au catalogue, hors mandat de l'issue #88. " +
+      "aide-lunettes-quebec/page.tsx source desormais ces deux entrees via getProgrammeFromCatalogue, fermant le " +
+      "dernier residu verrouille par programme-catalogue-drift.test.mjs depuis l'issue #86.",
     reviewCadence: "quarterly",
     nextReviewAt: "2026-12-01",
     criticality: "medium",

--- a/src/data/programmes.json
+++ b/src/data/programmes.json
@@ -1332,21 +1332,44 @@
     }
   },
   {
+    "id": "credit-frais-medicaux-fed",
+    "nom": "Crédit d'impôt pour frais médicaux (fédéral)",
+    "organisme": "Agence du revenu du Canada",
+    "niveau": "federal",
+    "categorie": "credits_impot",
+    "montant_min": 0,
+    "montant_max": 0,
+    "montant_affiche": "Montant calculé par l’ARC — à vérifier",
+    "montant_sommable": false,
+    "description": "Crédit d'impôt fédéral non remboursable de 15 % sur les frais médicaux admissibles (lignes 33099/33199 de la déclaration, incluant lunettes et verres de contact prescrits) qui dépassent le moindre de 2 834 $ ou 3 % du revenu net du demandeur. 2 834 $ est le seuil confirmé par l'ARC pour l'année d'imposition 2025, la dernière valeur publiée au moment de cette revalidation (2026-09-05); le seuil indexé de l'année d'imposition 2026 n'est pas encore publié par l'ARC.",
+    "conditions": [
+      "Résider au Canada",
+      "Produire une déclaration de revenus fédérale",
+      "Frais médicaux admissibles dépassant le moindre de 2 834 $ (année d'imposition 2025) ou 3 % du revenu net",
+      "Conserver les reçus (lunettes, verres de contact, montures, etc.)"
+    ],
+    "lien_officiel": "https://www.canada.ca/fr/agence-revenu/services/impot/particuliers/sujets/tout-votre-declaration-revenus/declaration-revenus/remplir-declaration-revenus/deductions-credits-depenses/lignes-33099-33199-frais-medicaux-admissibles-vous-pouvez-demander-votre-declaration-revenus.html",
+    "criteres": {
+      "provinces": ["QC", "ON", "BC", "AB", "MB", "SK", "NB", "NS", "PE", "NL"]
+    }
+  },
+  {
     "id": "credit-frais-medicaux-qc",
     "nom": "Crédit d'impôt pour frais médicaux (Québec)",
     "organisme": "Revenu Québec",
     "niveau": "provincial",
     "categorie": "credits_impot",
-    "montant_min": 50,
-    "montant_max": 400,
-    "montant_affiche": "50 $ – 400 $ (selon dépenses médicales)",
-    "description": "Crédit d'impôt non remboursable de 20 % sur les frais médicaux admissibles dépassant 3 % de votre revenu familial net (lunettes, médicaments, soins dentaires, prothèses, etc.), sans plafond en dollars fixe pour ce seuil au Québec. Ne s'applique que si vos frais médicaux réels dépassent le seuil minimal. Montant indicatif — varie entièrement selon les dépenses engagées.",
+    "montant_min": 0,
+    "montant_max": 0,
+    "montant_affiche": "Montant déterminé par Revenu Québec — à vérifier",
+    "montant_sommable": false,
+    "description": "Crédit d'impôt non remboursable de 20 % sur les frais médicaux admissibles dépassant 3 % de votre revenu familial net (lunettes et verres de contact prescrits, médicaments, soins dentaires, prothèses, etc.), sans plafond en dollars fixe pour ce seuil au Québec (contrairement au crédit fédéral équivalent, qui applique un seuil fixe indexé annuellement). Depuis le 1er janvier 2026, les frais payés aux homéopathes, naturopathes, ostéopathes et phytothérapeutes ne sont plus admissibles à ce crédit. Ne s'applique que si vos frais médicaux réels dépassent le seuil minimal.",
     "conditions": [
       "Résider au Québec",
       "Avoir des frais médicaux admissibles dépassant 3 % du revenu familial net (sans plafond en dollars fixe côté Québec; un seuil fixe distinct s'applique au crédit fédéral équivalent)",
       "Produire une déclaration de revenus au Québec"
     ],
-    "lien_officiel": "https://www.revenuquebec.ca/fr/citoyens/credits-dimpot/credit-dimpot-pour-frais-medicaux/",
+    "lien_officiel": "https://www.revenuquebec.ca/fr/citoyens/credits-dimpot/frais-medicaux/",
     "criteres": {
       "provinces": ["QC"]
     }

--- a/src/data/programmes.json
+++ b/src/data/programmes.json
@@ -1341,7 +1341,7 @@
     "montant_max": 0,
     "montant_affiche": "Montant calculé par l’ARC — à vérifier",
     "montant_sommable": false,
-    "description": "Crédit d'impôt fédéral non remboursable de 15 % sur les frais médicaux admissibles (lignes 33099/33199 de la déclaration, incluant lunettes et verres de contact prescrits) qui dépassent le moindre de 2 834 $ ou 3 % du revenu net du demandeur. 2 834 $ est le seuil confirmé par l'ARC pour l'année d'imposition 2025, la dernière valeur publiée au moment de cette revalidation (2026-09-05); le seuil indexé de l'année d'imposition 2026 n'est pas encore publié par l'ARC.",
+    "description": "Crédit d'impôt fédéral non remboursable sur les frais médicaux admissibles (lignes 33099/33199 de la déclaration, incluant lunettes et verres de contact prescrits) qui dépassent le moindre de 2 834 $ ou 3 % du revenu net du demandeur. Le taux, historiquement de 15 %, est de 14 % pour l'année d'imposition 2026 et suivantes (14,5 % en 2025, année de transition) : le premier taux d'imposition fédéral — auquel les crédits non remboursables comme celui-ci sont légalement arrimés — a été abaissé de 15 % à 14 % à compter de 2026 (Ministère des Finances du Canada, Report on the Impact of Reducing the Lowest Marginal Personal Income Tax Rate on Non-Refundable Tax Credits). 2 834 $ est le seuil confirmé par l'ARC pour l'année d'imposition 2025, la dernière valeur publiée au moment de cette revalidation (2026-09-05); le seuil indexé de l'année d'imposition 2026 n'est pas encore publié par l'ARC.",
     "conditions": [
       "Résider au Canada",
       "Produire une déclaration de revenus fédérale",

--- a/tests/programme-catalogue-drift.test.mjs
+++ b/tests/programme-catalogue-drift.test.mjs
@@ -285,16 +285,19 @@ test("vehicule-electrique-quebec sources subv-auto-elec-qc and subv-bornes-recha
   assert.match(source, /getProgrammeFromCatalogue\("subv-bornes-recharge-qc"\)/);
 });
 
-test("aide-lunettes-quebec consolidates its credit-solidarite-sante alias onto the catalogue's credit-loyer-qc, but keeps frais-medicaux-fed/frais-medicaux-qc local (no catalogue entry represents the same claim without revalidating it)", () => {
+test("aide-lunettes-quebec sources credit-loyer-qc, credit-frais-medicaux-fed and credit-frais-medicaux-qc from the catalogue, closing the #86 residual resolved by issue #88", () => {
   const source = read(path.join(appDir, "aide-lunettes-quebec", "page.tsx"));
   assert.match(source, /getProgrammeFromCatalogue\("credit-loyer-qc"\)/);
+  assert.match(source, /getProgrammeFromCatalogue\("credit-frais-medicaux-fed"\)/);
+  assert.match(source, /getProgrammeFromCatalogue\("credit-frais-medicaux-qc"\)/);
   assert.doesNotMatch(source, /id:\s*"credit-solidarite-sante"/);
-
-  const copies = extractLocalProgrammeCopies(source);
-  const copiedIds = copies.map((copy) => copy.id).sort();
-  assert.deepEqual(copiedIds, ["frais-medicaux-fed", "frais-medicaux-qc"]);
+  assert.deepEqual(extractLocalProgrammeCopies(source), []);
 
   const catalogue = JSON.parse(read(programmesJsonFile));
-  assert.equal(catalogue.find((p) => p.id === "frais-medicaux-fed"), undefined);
-  assert.equal(catalogue.find((p) => p.id === "frais-medicaux-qc"), undefined);
+  const fed = catalogue.find((p) => p.id === "credit-frais-medicaux-fed");
+  const qc = catalogue.find((p) => p.id === "credit-frais-medicaux-qc");
+  assert.ok(fed, "expected credit-frais-medicaux-fed in the governed catalogue");
+  assert.ok(qc, "expected credit-frais-medicaux-qc in the governed catalogue");
+  assert.deepEqual({ min: fed.montant_min, max: fed.montant_max }, { min: 0, max: 0 });
+  assert.deepEqual({ min: qc.montant_min, max: qc.montant_max }, { min: 0, max: 0 });
 });

--- a/tests/programmes-matching.test.mjs
+++ b/tests/programmes-matching.test.mjs
@@ -640,6 +640,33 @@ test("programmes.json catalogue size is stable and every entry has a non-empty d
   }
 });
 
+// issue #88, independent-review response: the lowest federal personal tax
+// rate (to which most non-refundable credits, including medical expenses,
+// are legally pegged) dropped from 15% to 14.5% for 2025 and 14% for 2026
+// onward (Finance Canada, "Report on the Impact of Reducing the Lowest
+// Marginal Personal Income Tax Rate on Non-Refundable Tax Credits"). Guards
+// against silently reverting to the stale 15% figure. The Québec ligne 381
+// credit is a separate, fixed 20% rate not tied to that mechanism (Revenu
+// Québec's own ligne-381 help page, the CFFP's dedicated 2025 fiche, and
+// Raymond Chabot Grant Thornton's Planiguide all confirm 20% for 2025/2026)
+// -- a NO-GO review claiming it should also read 14% was independently
+// re-verified and rejected; this guards against reintroducing that error.
+test("credit-frais-medicaux-fed states the 2026 federal rate (14%), and credit-frais-medicaux-qc keeps its own 20% rate (issue #88 independent-review response)", () => {
+  const programmes = loadProgrammesJson();
+  const fed = programmes.find((p) => p.id === "credit-frais-medicaux-fed");
+  const qc = programmes.find((p) => p.id === "credit-frais-medicaux-qc");
+
+  assert.ok(fed, "expected credit-frais-medicaux-fed in the catalogue");
+  assert.ok(qc, "expected credit-frais-medicaux-qc in the catalogue");
+  assert.match(fed.description, /14 ?%/, "federal medical expense credit must state the 2026 rate of 14%, not the stale 15%");
+  assert.doesNotMatch(
+    fed.description,
+    /non remboursable de 15/,
+    "federal medical expense credit must not headline the pre-2026 15% rate as current (mentioning it as prior history is fine)",
+  );
+  assert.match(qc.description, /20 ?%/, "Québec ligne 381 medical expense credit must keep its own 20% rate");
+});
+
 // issue #67: income bucketing regression tests.
 //
 // Same root cause as issue #58 (age), but for revenu_min/revenu_max: parseRevenu()

--- a/tests/programmes-matching.test.mjs
+++ b/tests/programmes-matching.test.mjs
@@ -630,7 +630,7 @@ test("physical-work programmes require renovation:true and are excluded when the
 test("programmes.json catalogue size is stable and every entry has a non-empty description (issue #51)", () => {
   const programmes = loadProgrammesJson();
 
-  assert.equal(programmes.length, 84, "unexpected catalogue size change -- update this count deliberately if programmes were added/removed");
+  assert.equal(programmes.length, 85, "unexpected catalogue size change -- update this count deliberately if programmes were added/removed");
 
   for (const programme of programmes) {
     assert.ok(


### PR DESCRIPTION
## Résumé

- Ferme le résidu de l'issue #86 (verrouillé par `programme-catalogue-drift.test.mjs`) : `aide-lunettes-quebec/page.tsx` source désormais ses deux crédits pour frais médicaux via `getProgrammeFromCatalogue()` au lieu d'objets `Programme` locaux.
- Ajoute `credit-frais-medicaux-fed` au catalogue central (absent jusqu'ici) et corrige `credit-frais-medicaux-qc`, dont la fourchette affichée (50 $–400 $) contredisait sa propre description ("sans plafond en dollars fixe").
- Revalidation source-backed (ARC lignes 33099/33199, Revenu Québec ligne 381) : seuil fédéral 2 834 $ (année d'imposition 2025, l'ancien "2 635 $ en 2026" était en réalité le seuil 2023 mal daté), et retrait 2026 des homéopathes/naturopathes/ostéopathes/phytothérapeutes du crédit québécois.
- **Suite à une revue indépendante NO-GO publiée sur l'issue** : le taux fédéral a été corrigé de 15 % à **14 %** (le premier taux d'imposition fédéral, auquel les crédits non remboursables sont légalement arrimés, est passé à 14,5 % en 2025 puis 14 % en 2026 — Ministère des Finances du Canada, confirmé par l'ARC et KPMG). Une seconde correction proposée par cette même revue (Québec 20 % → 14 %) a été **rejetée après contre-vérification indépendante** : trois sources récentes et spécifiques à ce crédit (page d'aide officielle Revenu Québec ligne 381, fiche CFFP 2025, Planiguide RCGT) confirment toutes 20 %, sans lien avec la réforme 2017 qui a arrimé d'autres crédits au barème. Détail complet des deux vérifications dans le `sourceNote` de `programmes-2026.ts` et dans les commentaires de l'issue #88.

## Fichiers modifiés

- `src/app/aide-lunettes-quebec/page.tsx`
- `src/data/programmes.json`
- `src/data/finance-2026/programmes-2026.ts`
- `tests/programme-catalogue-drift.test.mjs`
- `tests/programmes-matching.test.mjs`

## Tests

- `npm run test:unit` → 251/251 tests passent (test ciblé ajouté verrouillant 14 % fédéral / 20 % Québec dans les deux sens).
- `npm run check:seo` → passe (4 avertissements de fraîcheur non bloquants pré-existants et sans rapport).
- `npm run lint` → 0 erreur/avertissement.
- `npm run build` → succès.

## Notes

WebFetch reste `EGRESS_BLOCKED` sur `canada.ca`, `revenuquebec.ca` et `budget.finances.gouv.qc.ca` dans cet environnement ; revalidation faite par recherche web convergente sur plusieurs sources indépendantes par fait, comme pour les revalidations précédentes du dépôt (#47, #49, #51, #83).

Closes #88.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jq8ZUYuNXZxvSBw94JAG1n


---
_Generated by [Claude Code](https://claude.ai/code/session_01Jq8ZUYuNXZxvSBw94JAG1n)_