### PR TITLE
Corrige la page frais médicaux QC et élimine les données fiscales locales divergentes

### DIFF
--- a/src/app/credit-impot-frais-medicaux-quebec/page.tsx
+++ b/src/app/credit-impot-frais-medicaux-quebec/page.tsx
@@ -50,7 +50,7 @@ export default function CreditImpotFraisMedicauxPage() {
   return (
     <SeoProgrammesPage
       titre="Crédit d'impôt pour frais médicaux Québec 2026"
-      sousTitre="Récupérez 20% de vos dépenses médicales admissibles au provincial, en plus du crédit fédéral — lunettes, dentiste, médicaments et plus."
+      sousTitre="Récupérez 20% de la portion de vos dépenses médicales admissibles qui dépasse 3% de votre revenu familial net (crédit non remboursable, ligne 381), en plus du crédit fédéral — lunettes, dentiste, médicaments et plus."
       intro="Le crédit d'impôt pour frais médicaux est l'un des crédits les plus méconnus et pourtant les plus accessibles. Au Québec, le crédit provincial est non remboursable et récupère 20% de vos dépenses médicales admissibles qui dépassent 3% de votre revenu familial net, en plus du crédit fédéral (14% pour l'année d'imposition 2026, sur les dépenses dépassant le moindre de 3% du revenu net ou 2 834 $ pour 2025 — le seuil 2026 n'est pas encore publié par l'ARC). Une famille qui cumule dentiste, lunettes et médicaments sur ordonnance peut facilement réclamer 2 000 $ à 5 000 $ en dépenses admissibles — et récupérer plusieurs centaines de dollars. La clé : garder tous ses reçus."
       programmes={programmes}
       faqs={faqs}

--- a/src/app/credit-impot-frais-medicaux-quebec/page.tsx
+++ b/src/app/credit-impot-frais-medicaux-quebec/page.tsx
@@ -11,44 +11,19 @@ export const metadata: Metadata = {
 };
 
 const programmes: Programme[] = [
-  {
-    id: "frais-medicaux-qc-2",
-    nom: "Crédit d'impôt pour frais médicaux (Québec)",
-    organisme: "Revenu Québec",
-    niveau: "provincial",
-    categorie: "sante",
-    montant_min: 0,
-    montant_max: 2000,
-    montant_affiche: "Jusqu'à 20% des dépenses",
-    description: "Crédit d'impôt remboursable sur vos frais médicaux admissibles. Le taux varie entre 5% et 20% selon votre revenu familial — les ménages à faible revenu reçoivent un crédit plus élevé. Couvre lunettes, médicaments sur ordonnance, dentiste, physio, et plus.",
-    conditions: [
-      "Résider au Québec",
-      "Produire une déclaration de revenus provinciale",
-      "Frais médicaux payés pour vous, votre conjoint ou vos enfants à charge",
-      "Conserver tous les reçus et ordonnances"
-    ],
-    lien_officiel: "https://www.revenuquebec.ca/fr/citoyens/credits-dimpot/credit-dimpot-pour-frais-medicaux/",
-    criteres: { provinces: ["QC"] },
-  },
-  {
-    id: "frais-medicaux-fed-2",
-    nom: "Crédit d'impôt pour frais médicaux (fédéral)",
-    organisme: "Gouvernement du Canada",
-    niveau: "federal",
-    categorie: "sante",
-    montant_min: 0,
-    montant_max: 3000,
-    montant_affiche: "15% des dépenses au-delà du seuil",
-    description: "Crédit d'impôt fédéral de 15% sur les frais médicaux admissibles dépassant 3% de votre revenu net (ou 2 635 $ en 2026). Cumulable avec le crédit provincial québécois.",
-    conditions: [
-      "Résider au Canada",
-      "Dépenses dépassant 3% du revenu net ou 2 635 $ (le moins élevé)",
-      "Frais pour vous, votre conjoint ou vos enfants à charge",
-      "Reçus obligatoires"
-    ],
-    lien_officiel: "https://www.canada.ca/fr/agence-revenu/services/impot/particuliers/sujets/tout-votre-declaration-revenus/declaration-revenus/remplir-declaration-revenus/deductions-credits-depenses/ligne-33099-33199-depenses-admissibles-frais-medicaux.html",
-    criteres: { provinces: ["QC", "ON", "BC", "AB", "MB", "SK", "NB", "NS", "PE", "NL"] },
-  },
+  // frais-medicaux-qc-2/frais-medicaux-fed-2 were page-local copies that
+  // drifted from the governed catalogue (issue #93): they still claimed a
+  // refundable, income-variable-rate Québec credit and an outdated federal
+  // rate paired with a stale dollar threshold presented as current. Issue
+  // #88 revalidated both credits against official sources (ARC line
+  // 33099/33199; Revenu Québec ligne 381): Québec's credit is non-refundable
+  // at a fixed 20% on expenses above 3% of net family income (no fixed
+  // dollar cap), and the federal rate/threshold are the 2026 governed values
+  // below. Both credits now source the catalogue under
+  // credit-frais-medicaux-qc/-fed; see the durable reports on issues #88 and
+  // #93 for the full revalidation detail.
+  getProgrammeFromCatalogue("credit-frais-medicaux-qc"),
+  getProgrammeFromCatalogue("credit-frais-medicaux-fed"),
   getProgrammeFromCatalogue("credit-maintien-qc"),
 ];
 
@@ -59,7 +34,7 @@ const faqs = [
   },
   {
     question: "Comment calculer mon crédit d'impôt pour frais médicaux ?",
-    reponse: "Au fédéral : additionnez toutes vos dépenses médicales de 12 mois consécutifs, soustrayez le seuil (3% de votre revenu net ou 2 635 $, le moins élevé), et multipliez par 15%. Au provincial : le calcul est similaire mais le taux varie entre 5% et 20% selon votre revenu. Les deux crédits sont cumulables.",
+    reponse: "Au fédéral : additionnez toutes vos dépenses médicales de 12 mois consécutifs, soustrayez le seuil (le moindre de 3% de votre revenu net ou 2 834 $ pour l'année d'imposition 2025 — le seuil 2026 n'est pas encore publié par l'ARC), et multipliez par 14% (taux en vigueur pour 2026). Au provincial : le crédit québécois est non remboursable, à un taux fixe de 20% sur la partie des dépenses admissibles qui dépasse 3% de votre revenu familial net, sans plafond en dollars fixe. Les deux crédits sont cumulables.",
   },
   {
     question: "Puis-je inclure les frais médicaux de mon conjoint et de mes enfants ?",
@@ -75,8 +50,8 @@ export default function CreditImpotFraisMedicauxPage() {
   return (
     <SeoProgrammesPage
       titre="Crédit d'impôt pour frais médicaux Québec 2026"
-      sousTitre="Récupérez jusqu'à 20% de vos dépenses médicales — lunettes, dentiste, médicaments et plus."
-      intro="Le crédit d'impôt pour frais médicaux est l'un des crédits les plus méconnus et pourtant les plus accessibles. Au Québec, vous pouvez récupérer jusqu'à 20% de vos dépenses médicales admissibles grâce au crédit provincial, en plus du 15% fédéral. Une famille qui cumule dentiste, lunettes et médicaments sur ordonnance peut facilement réclamer 2 000 $ à 5 000 $ en dépenses admissibles — et récupérer plusieurs centaines de dollars. La clé : garder tous ses reçus."
+      sousTitre="Récupérez 20% de vos dépenses médicales admissibles au provincial, en plus du crédit fédéral — lunettes, dentiste, médicaments et plus."
+      intro="Le crédit d'impôt pour frais médicaux est l'un des crédits les plus méconnus et pourtant les plus accessibles. Au Québec, le crédit provincial est non remboursable et récupère 20% de vos dépenses médicales admissibles qui dépassent 3% de votre revenu familial net, en plus du crédit fédéral (14% pour l'année d'imposition 2026, sur les dépenses dépassant le moindre de 3% du revenu net ou 2 834 $ pour 2025 — le seuil 2026 n'est pas encore publié par l'ARC). Une famille qui cumule dentiste, lunettes et médicaments sur ordonnance peut facilement réclamer 2 000 $ à 5 000 $ en dépenses admissibles — et récupérer plusieurs centaines de dollars. La clé : garder tous ses reçus."
       programmes={programmes}
       faqs={faqs}
       motCle="Crédit impôt frais médicaux Québec 2026"

--- a/tests/programme-catalogue-drift.test.mjs
+++ b/tests/programme-catalogue-drift.test.mjs
@@ -301,3 +301,20 @@ test("aide-lunettes-quebec sources credit-loyer-qc, credit-frais-medicaux-fed an
   assert.deepEqual({ min: fed.montant_min, max: fed.montant_max }, { min: 0, max: 0 });
   assert.deepEqual({ min: qc.montant_min, max: qc.montant_max }, { min: 0, max: 0 });
 });
+
+test("credit-impot-frais-medicaux-quebec sources credit-frais-medicaux-qc and credit-frais-medicaux-fed from the catalogue instead of the competing frais-medicaux-qc-2/frais-medicaux-fed-2 local copies (issue #93)", () => {
+  const source = read(path.join(appDir, "credit-impot-frais-medicaux-quebec", "page.tsx"));
+  assert.deepEqual(extractLocalProgrammeCopies(source), []);
+  assert.match(source, /getProgrammeFromCatalogue\("credit-frais-medicaux-qc"\)/);
+  assert.match(source, /getProgrammeFromCatalogue\("credit-frais-medicaux-fed"\)/);
+  assert.doesNotMatch(source, /id:\s*"frais-medicaux-qc-2"/);
+  assert.doesNotMatch(source, /id:\s*"frais-medicaux-fed-2"/);
+
+  // The page must no longer assert the pre-#88 15% federal rate, the old
+  // 2 635 $ (2023) threshold presented as current, or the Québec credit as
+  // refundable / variable 5%-20%.
+  assert.doesNotMatch(source, /15%/);
+  assert.doesNotMatch(source, /2 ?635 ?\$/);
+  assert.doesNotMatch(source, /remboursable sur vos frais médicaux/);
+  assert.doesNotMatch(source, /5% et 20%/);
+});


### PR DESCRIPTION
Closes #93

## Root cause

`src/app/credit-impot-frais-medicaux-quebec/page.tsx` portait deux objets `Programme` locaux (`frais-medicaux-qc-2`, `frais-medicaux-fed-2`) qui dupliquaient les mêmes bénéfices réels que `credit-frais-medicaux-qc`/`credit-frais-medicaux-fed`, contournant le garde-fou de dérive du catalogue introduit par l'issue #88. Ces copies locales n'avaient pas été mises à jour lors de la revalidation #88 et affichaient donc des données obsolètes.

## Valeurs avant / après

| Donnée | Avant (page locale) | Après (catalogue gouverné, issue #88) |
|---|---|---|
| Crédit fédéral — taux | 15 % | 14 % (année d'imposition 2026) |
| Crédit fédéral — seuil | « 2 635 $ » présenté comme actuel en 2026 (valeur 2023) | Seuil = moindre de 3 % du revenu net ou 2 834 $ (dernière valeur ARC confirmée, année d'imposition 2025) ; aucune valeur 2026 non publiée n'est inventée |
| Crédit québécois — remboursabilité | Décrit comme remboursable | Non remboursable |
| Crédit québécois — taux | Variable 5 % à 20 % selon le revenu | Fixe à 20 % sur la partie excédant 3 % du revenu familial net |

## Source de vérité catalogue utilisée

`src/data/programmes.json` — entrées `credit-frais-medicaux-fed` et `credit-frais-medicaux-qc` (gouvernées et revalidées par l'issue #88), consommées via `getProgrammeFromCatalogue()` (`src/data/finance-2026`).

## Fichiers modifiés

- `src/app/credit-impot-frais-medicaux-quebec/page.tsx` : suppression des deux objets `Programme` locaux ; remplacement par `getProgrammeFromCatalogue("credit-frais-medicaux-qc")` / `getProgrammeFromCatalogue("credit-frais-medicaux-fed")` ; réécriture du contenu éditorial (sous-titre, intro, FAQ « Comment calculer ») pour cohérence stricte avec les valeurs gouvernées.
- `tests/programme-catalogue-drift.test.mjs` : nouveau test garde-fou qui échoue si la page réintroduit les objets locaux concurrents (`frais-medicaux-qc-2`/`frais-medicaux-fed-2`) ou les affirmations obsolètes (15 %, 2 635 $, « remboursable », taux variable 5 %-20 %).

Aucun autre contenu (autres pages, autres programmes) n'a été modifié. `aide-lunettes-quebec` conserve son propre contenu hors scope de cette issue.

## Confirmation — aucune valeur 2026 non publiée inventée

Le seuil fédéral 2026 en dollars n'est pas publié par l'ARC au moment de cette correction (2026-09-05). La page utilise une formulation prudente et explicite (« 2 834 $ pour l'année d'imposition 2025 — le seuil 2026 n'est pas encore publié par l'ARC ») plutôt que d'extrapoler une valeur.

## Tests / gates exécutés

- `npm run check:seo` → PASS
- `npm run test:unit` → PASS (252/252, incluant le nouveau test garde-fou)
- `npm run lint` → PASS (aucune erreur)
- `npm run build` → PASS (`/credit-impot-frais-medicaux-quebec` prerendue statiquement sans erreur)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BHJweokAFXPgFEZSV7Uzc4

---
_Generated by [Claude Code](https://claude.ai/code/session_01BHJweokAFXPgFEZSV7Uzc4)_