### PR TITLE
Ferme le trou de gouvernance des pages *-quebec (issue #96)

### DIFF
--- a/scripts/check-seo.mjs
+++ b/scripts/check-seo.mjs
@@ -13,7 +13,7 @@ import {
   validateRegistryEntryShape,
 } from "./lib/claims-freshness.mjs";
 import { findUnregisteredIndexableRoutes } from "./lib/route-registry.mjs";
-import { findProgrammeCatalogueDrift, isMiddlewareRedirectedRoute } from "./lib/programme-catalogue-drift.mjs";
+import { findProgrammeCatalogueDrift, findUngovernedLocalProgrammes, isMiddlewareRedirectedRoute } from "./lib/programme-catalogue-drift.mjs";
 
 const rootDir = process.cwd();
 const appDir = path.join(rootDir, "src", "app");
@@ -52,6 +52,16 @@ const freshnessNowEnvVar = "ARGENTQC_FRESHNESS_NOW";
 const legitimateSeoRegistryExceptions = [
   "/politique-confidentialite", // registered directly in sitemap.ts legalEntries
 ];
+
+// Pages explicitly allowed to keep a raw local Programme object literal
+// inside the governed `const programmes: Programme[] = [...]` array
+// instead of sourcing it via getProgrammeFromCatalogue (issue #96). Empty
+// by design: every page currently opting into that array pattern sources
+// 100% of its entries from src/data/programmes.json. Adding an entry here
+// requires a one-line justification (the benefit genuinely has no
+// catalogue counterpart yet) and a regression test - it must never be used
+// to silence a real duplicate.
+const governedProgrammeSourcingExceptions = [];
 
 const errors = [];
 
@@ -998,6 +1008,19 @@ function checkProgrammeCatalogueDrift() {
     report("SEO page programme copy has drifted from the governed programmes catalogue", [
       `${relative(drift.filePath)}: "${drift.id}" montant_min/montant_max is ${drift.local.montant_min}/${drift.local.montant_max}, ` +
         `but ${relative(programmesJsonFile)} has ${drift.canonical.montant_min}/${drift.canonical.montant_max}`,
+    ]);
+  }
+
+  const exceptions = governedProgrammeSourcingExceptions.map((exception) => ({
+    ...exception,
+    filePath: relative(path.join(rootDir, exception.filePath)),
+  }));
+  const relativePages = pages.map(({ filePath, source }) => ({ filePath: relative(filePath), source }));
+  const ungoverned = findUngovernedLocalProgrammes({ pages: relativePages, exceptions });
+  for (const violation of ungoverned) {
+    report("SEO page defines a local Programme object instead of sourcing it from the governed catalogue", [
+      `${violation.filePath}: "${violation.id}" is a raw object literal in the governed programmes array; ` +
+        `use getProgrammeFromCatalogue("${violation.id}") or add ${violation.filePath}/${violation.id} to governedProgrammeSourcingExceptions in scripts/check-seo.mjs with a justification`,
     ]);
   }
 }

--- a/scripts/check-seo.mjs
+++ b/scripts/check-seo.mjs
@@ -55,13 +55,24 @@ const legitimateSeoRegistryExceptions = [
 
 // Pages explicitly allowed to keep a raw local Programme object literal
 // inside the governed `const programmes: Programme[] = [...]` array
-// instead of sourcing it via getProgrammeFromCatalogue (issue #96). Empty
-// by design: every page currently opting into that array pattern sources
-// 100% of its entries from src/data/programmes.json. Adding an entry here
-// requires a one-line justification (the benefit genuinely has no
-// catalogue counterpart yet) and a regression test - it must never be used
-// to silence a real duplicate.
-const governedProgrammeSourcingExceptions = [];
+// instead of sourcing it via getProgrammeFromCatalogue (issue #96). Every
+// entry here must be a one-line justification and, other than this single
+// tracked case, must never be used to silence a real duplicate:
+//
+// - credit-impot-quebec/page.tsx: credit-loyer-qc, credit-tps-fed, and
+//   credit-reno-fed already match the catalogue's montant_min/montant_max
+//   exactly (no active P1 drift), but their prose has diverged from the
+//   catalogue - notably credit-reno-fed's flat "15%" rate claim vs. the
+//   catalogue's documented 2026 federal rate uncertainty. Per #96's stop
+//   condition, that factual divergence is tracked and revalidated in
+//   follow-up issue #98 rather than silently corrected here; this
+//   exception is temporary and must be removed once #98 migrates these
+//   three entries onto getProgrammeFromCatalogue(...).
+const governedProgrammeSourcingExceptions = [
+  { filePath: "src/app/credit-impot-quebec/page.tsx", id: "credit-loyer-qc" }, // tracked in #98
+  { filePath: "src/app/credit-impot-quebec/page.tsx", id: "credit-tps-fed" }, // tracked in #98
+  { filePath: "src/app/credit-impot-quebec/page.tsx", id: "credit-reno-fed" }, // tracked in #98
+];
 
 const errors = [];
 

--- a/scripts/lib/programme-catalogue-drift.mjs
+++ b/scripts/lib/programme-catalogue-drift.mjs
@@ -93,6 +93,99 @@ export function isMiddlewareRedirectedRoute(routePath, middlewareSource) {
   return new RegExp(`"${escaped}":\\s*"`).test(middlewareSource);
 }
 
+// Splits an array-literal text (including its outer [ ]) into its
+// top-level comma-separated elements, respecting nested {}, [], (), and
+// quoted strings. Unlike splitTopLevelBraceObjects, an element does not
+// have to be a `{ ... }` object literal - it can equally be a call
+// expression like `getProgrammeFromCatalogue("id")` - so this is the
+// primitive findUngovernedLocalProgrammes needs to tell the two shapes
+// apart per array entry.
+export function splitTopLevelArrayElements(arrayText) {
+  const inner = arrayText.slice(1, -1);
+  const elements = [];
+  let depth = 0;
+  let quote = null;
+  let escaped = false;
+  let start = 0;
+
+  for (let i = 0; i < inner.length; i += 1) {
+    const char = inner[i];
+
+    if (quote) {
+      if (escaped) {
+        escaped = false;
+      } else if (char === "\\") {
+        escaped = true;
+      } else if (char === quote) {
+        quote = null;
+      }
+      continue;
+    }
+
+    if (char === "\"" || char === "'" || char === "`") {
+      quote = char;
+      continue;
+    }
+
+    if (char === "{" || char === "[" || char === "(") {
+      depth += 1;
+    } else if (char === "}" || char === "]" || char === ")") {
+      depth -= 1;
+    } else if (char === "," && depth === 0) {
+      elements.push(inner.slice(start, i).trim());
+      start = i + 1;
+    }
+  }
+
+  const last = inner.slice(start).trim();
+  if (last) elements.push(last);
+
+  return elements.filter(Boolean);
+}
+
+const CATALOGUE_CALL_PATTERN = /^getProgrammeFromCatalogue\(\s*"[^"]+"\s*\)$/;
+
+// Structural guardrail for issue #96 (gap left open by #69/#93): id-based
+// drift detection (findProgrammeCatalogueDrift above) only catches a local
+// copy when it reuses the *same* id as a catalogue entry. It cannot catch
+// the historical frais-medicaux-qc-2/frais-medicaux-fed-2 pattern (#93),
+// where a page recreated an already-governed benefit under a *different*
+// local id - there is no shared id for the comparison to key on.
+//
+// The chosen invariant does not try to detect "same benefit, different id"
+// semantically (fragile, un-reviewable). Instead it is deterministic and
+// structural: a page that opts into the governed array pattern (the same
+// `const programmes: Programme[] = [...]` literal SeoProgrammesPage
+// consumes) must source *every* entry through getProgrammeFromCatalogue().
+// A raw `{ id: ..., ... }` object literal anywhere in that array is
+// rejected outright, regardless of whether its id happens to collide with
+// a catalogue entry - so a new local id can never smuggle in a duplicate
+// benefit. Legitimate local-only entries (a benefit not yet catalogued)
+// must be added to `exceptions` explicitly, one line per (file, id), so
+// the exception is reviewable and bounded rather than a silent gap.
+export function findUngovernedLocalProgrammes({ pages, exceptions = [] }) {
+  const exceptionKeys = new Set(exceptions.map(({ filePath, id }) => `${filePath}::${id}`));
+  const violations = [];
+
+  for (const { filePath, source } of pages) {
+    const arrayText = extractProgrammeArrayText(source);
+    if (!arrayText) continue;
+
+    for (const element of splitTopLevelArrayElements(arrayText)) {
+      if (CATALOGUE_CALL_PATTERN.test(element)) continue;
+      if (!element.startsWith("{")) continue;
+
+      const idMatch = element.match(/\bid:\s*"([^"]+)"/);
+      const id = idMatch ? idMatch[1] : "(unknown id)";
+      if (exceptionKeys.has(`${filePath}::${id}`)) continue;
+
+      violations.push({ filePath, id });
+    }
+  }
+
+  return violations;
+}
+
 /**
  * @param {{ filePath: string, source: string }[]} pages
  * @param {{ id: string, montant_min: number, montant_max: number }[]} catalogue

--- a/scripts/lib/programme-catalogue-drift.mjs
+++ b/scripts/lib/programme-catalogue-drift.mjs
@@ -100,8 +100,64 @@ export function isMiddlewareRedirectedRoute(routePath, middlewareSource) {
 // expression like `getProgrammeFromCatalogue("id")` - so this is the
 // primitive findUngovernedLocalProgrammes needs to tell the two shapes
 // apart per array entry.
+// Blanks out // line comments and /* */ block comments (replacing them with
+// spaces, so character offsets and line breaks are preserved) while leaving
+// quoted strings untouched, so a `//`/`/*` inside a "montant_affiche" string
+// is never mistaken for a comment. Array-literal comments between entries
+// (see aide-lunettes-quebec/page.tsx) must be removed before splitting on
+// top-level commas, or a comment would otherwise be mistaken for its own
+// array element.
+function blankComments(source) {
+  let result = "";
+  let quote = null;
+  let escaped = false;
+
+  for (let i = 0; i < source.length; i += 1) {
+    const char = source[i];
+    const next = source[i + 1];
+
+    if (quote) {
+      result += char;
+      if (escaped) {
+        escaped = false;
+      } else if (char === "\\") {
+        escaped = true;
+      } else if (char === quote) {
+        quote = null;
+      }
+      continue;
+    }
+
+    if (char === "\"" || char === "'" || char === "`") {
+      quote = char;
+      result += char;
+      continue;
+    }
+
+    if (char === "/" && next === "/") {
+      const end = source.indexOf("\n", i + 2);
+      const stop = end === -1 ? source.length : end;
+      result += " ".repeat(stop - i);
+      i = stop - 1;
+      continue;
+    }
+
+    if (char === "/" && next === "*") {
+      const end = source.indexOf("*/", i + 2);
+      const stop = end === -1 ? source.length : end + 2;
+      result += source.slice(i, stop).replace(/[^\n]/g, " ");
+      i = stop - 1;
+      continue;
+    }
+
+    result += char;
+  }
+
+  return result;
+}
+
 export function splitTopLevelArrayElements(arrayText) {
-  const inner = arrayText.slice(1, -1);
+  const inner = blankComments(arrayText.slice(1, -1));
   const elements = [];
   let depth = 0;
   let quote = null;
@@ -157,12 +213,20 @@ const CATALOGUE_CALL_PATTERN = /^getProgrammeFromCatalogue\(\s*"[^"]+"\s*\)$/;
 // structural: a page that opts into the governed array pattern (the same
 // `const programmes: Programme[] = [...]` literal SeoProgrammesPage
 // consumes) must source *every* entry through getProgrammeFromCatalogue().
-// A raw `{ id: ..., ... }` object literal anywhere in that array is
-// rejected outright, regardless of whether its id happens to collide with
-// a catalogue entry - so a new local id can never smuggle in a duplicate
-// benefit. Legitimate local-only entries (a benefit not yet catalogued)
-// must be added to `exceptions` explicitly, one line per (file, id), so
-// the exception is reviewable and bounded rather than a silent gap.
+// The check is default-deny, not default-allow: any top-level array
+// element that is not *exactly* a `getProgrammeFromCatalogue("id")` call is
+// rejected, whatever shape it takes - a raw `{ id: ..., ... }` object
+// literal, a variable reference to one declared above the array (e.g.
+// `const localProgramme = { id: ... }; const programmes = [localProgramme]`),
+// a `...spread` of a non-governed array, or any other helper/call. An
+// earlier version of this check only special-cased literal `{ ... }`
+// entries and silently ignored anything else, which a reviewer found still
+// let a hoisted-variable or spread indirection smuggle in a duplicate
+// benefit undetected. So a new local id (or an indirected one) can never
+// smuggle in a duplicate benefit. Legitimate local-only entries (a benefit
+// not yet catalogued) must be added to `exceptions` explicitly, one line
+// per (file, id), so the exception is reviewable and bounded rather than a
+// silent gap.
 export function findUngovernedLocalProgrammes({ pages, exceptions = [] }) {
   const exceptionKeys = new Set(exceptions.map(({ filePath, id }) => `${filePath}::${id}`));
   const violations = [];
@@ -173,10 +237,9 @@ export function findUngovernedLocalProgrammes({ pages, exceptions = [] }) {
 
     for (const element of splitTopLevelArrayElements(arrayText)) {
       if (CATALOGUE_CALL_PATTERN.test(element)) continue;
-      if (!element.startsWith("{")) continue;
 
       const idMatch = element.match(/\bid:\s*"([^"]+)"/);
-      const id = idMatch ? idMatch[1] : "(unknown id)";
+      const id = idMatch ? idMatch[1] : element.length > 60 ? `${element.slice(0, 60)}…` : element;
       if (exceptionKeys.has(`${filePath}::${id}`)) continue;
 
       violations.push({ filePath, id });

--- a/src/app/credit-impot-quebec/page.tsx
+++ b/src/app/credit-impot-quebec/page.tsx
@@ -10,20 +10,65 @@ export const metadata: Metadata = {
   keywords: ["crédit impôt Québec", "crédit impôt Québec combien", "crédits impôt remboursables Québec 2026", "récupérer impôt Québec"],
 };
 
+// credit-loyer-qc, credit-tps-fed, and credit-reno-fed below are page-local
+// copies of already-governed catalogue entries, caught by the new
+// findUngovernedLocalProgrammes() structural check (issue #96). Their
+// montant_min/montant_max match the catalogue exactly (no active P1 drift),
+// but the prose has already diverged - notably credit-reno-fed's flat 15%
+// rate claim vs. the catalogue's documented 2026 federal rate uncertainty.
+// Per #96's stop condition, that factual divergence is not corrected here:
+// it is tracked and revalidated in the dedicated follow-up issue #98, which
+// will migrate these three entries onto getProgrammeFromCatalogue(...) once
+// the rate is confirmed. Until then they are a declared, temporary
+// exception in governedProgrammeSourcingExceptions (scripts/check-seo.mjs).
 const programmes: Programme[] = [
-  // credit-loyer-qc, credit-tps-fed, and credit-reno-fed were page-local
-  // copies of already-governed catalogue entries (issue #96, the general
-  // structural fix that also closes #93's frais-medicaux-qc-2 pattern):
-  // their montant_min/montant_max matched the catalogue so the id-based
-  // drift gate saw no active P1, but the prose had already drifted (e.g.
-  // this page's credit-reno-fed described a flat 15% rate while the
-  // catalogue documents the 2026 federal rate uncertainty). Sourcing all
-  // four entries from the catalogue removes that second, less obvious
-  // source of truth.
-  getProgrammeFromCatalogue("credit-loyer-qc"),
-  getProgrammeFromCatalogue("credit-tps-fed"),
+  {
+    id: "credit-loyer-qc",
+    nom: "Crédit d'impôt pour solidarité",
+    organisme: "Revenu Québec",
+    niveau: "provincial",
+    categorie: "credits_impot",
+    montant_min: 0,
+    montant_max: 0,
+    montant_affiche: "Montant déterminé par Revenu Québec — à vérifier",
+    montant_sommable: false,
+    preselection_only: true,
+    description: "Crédit d'impôt remboursable combinant jusqu'à trois composantes : TVQ, logement et village nordique (pour les 14 villages nordiques du Nunavik). Montant et fréquence de versement déterminés par Revenu Québec selon le dossier complet.",
+    conditions: ["Résider au Québec au 31 décembre 2025", "Produire la déclaration de revenus 2025 et l'annexe D si le logement ou le village nordique s'appliquent", "Faire vérifier le montant par Revenu Québec"],
+    lien_officiel: "https://www.revenuquebec.ca/fr/citoyens/credits-dimpot/credit-dimpot-pour-solidarite/",
+    criteres: { provinces: ["QC"] },
+  },
+  {
+    id: "credit-tps-fed",
+    nom: "Allocation canadienne pour l’épicerie et les besoins essentiels (ACEBE)",
+    organisme: "Gouvernement du Canada",
+    niveau: "federal",
+    categorie: "credits_impot",
+    montant_min: 0,
+    montant_max: 0,
+    montant_affiche: "Montant calculé par l’ARC — à vérifier",
+    montant_sommable: false,
+    preselection_only: true,
+    description: "Prestation fédérale trimestrielle non imposable qui remplace le crédit pour la TPS/TVH depuis juillet 2026.",
+    conditions: ["Résider au Canada", "Produire une déclaration de revenus fédérale", "Faire vérifier le montant selon le RFNR 2025 et la composition familiale"],
+    lien_officiel: "https://www.canada.ca/fr/agence-revenu/services/prestations-enfants-familles/allocation-canadienne-epicerie-besoins-essentiels.html",
+    criteres: {},
+  },
   getProgrammeFromCatalogue("credit-maintien-qc"),
-  getProgrammeFromCatalogue("credit-reno-fed"),
+  {
+    id: "credit-reno-fed",
+    nom: "Crédit pour rénovations multigénérationnelles",
+    organisme: "Gouvernement du Canada",
+    niveau: "federal",
+    categorie: "credits_impot",
+    montant_min: 0,
+    montant_max: 7500,
+    montant_affiche: "Jusqu'à 7 500 $",
+    description: "Crédit d'impôt remboursable de 15% pour créer un logement secondaire dans votre domicile pour un aîné ou une personne handicapée.",
+    conditions: ["Créer un logement secondaire dans votre domicile", "Le logement est destiné à un aîné (65+) ou une personne handicapée", "Dépenses admissibles entre 500 $ et 50 000 $"],
+    lien_officiel: "https://www.canada.ca/fr/agence-revenu/programmes/a-propos-agence-revenu-canada-arc/impot-cible/credit-renovation-domiciliaire-multigeneration.html",
+    criteres: { proprietaire: true, renovation: true },
+  },
 ];
 
 const faqs = [

--- a/src/app/credit-impot-quebec/page.tsx
+++ b/src/app/credit-impot-quebec/page.tsx
@@ -11,53 +11,19 @@ export const metadata: Metadata = {
 };
 
 const programmes: Programme[] = [
-  {
-    id: "credit-loyer-qc",
-    nom: "Crédit d'impôt pour solidarité",
-    organisme: "Revenu Québec",
-    niveau: "provincial",
-    categorie: "credits_impot",
-    montant_min: 0,
-    montant_max: 0,
-    montant_affiche: "Montant déterminé par Revenu Québec — à vérifier",
-    montant_sommable: false,
-    preselection_only: true,
-    description: "Crédit d'impôt remboursable combinant jusqu'à trois composantes : TVQ, logement et village nordique (pour les 14 villages nordiques du Nunavik). Montant et fréquence de versement déterminés par Revenu Québec selon le dossier complet.",
-    conditions: ["Résider au Québec au 31 décembre 2025", "Produire la déclaration de revenus 2025 et l'annexe D si le logement ou le village nordique s'appliquent", "Faire vérifier le montant par Revenu Québec"],
-    lien_officiel: "https://www.revenuquebec.ca/fr/citoyens/credits-dimpot/credit-dimpot-pour-solidarite/",
-    criteres: { provinces: ["QC"] },
-  },
-  {
-    id: "credit-tps-fed",
-    nom: "Allocation canadienne pour l’épicerie et les besoins essentiels (ACEBE)",
-    organisme: "Gouvernement du Canada",
-    niveau: "federal",
-    categorie: "credits_impot",
-    montant_min: 0,
-    montant_max: 0,
-    montant_affiche: "Montant calculé par l’ARC — à vérifier",
-    montant_sommable: false,
-    preselection_only: true,
-    description: "Prestation fédérale trimestrielle non imposable qui remplace le crédit pour la TPS/TVH depuis juillet 2026.",
-    conditions: ["Résider au Canada", "Produire une déclaration de revenus fédérale", "Faire vérifier le montant selon le RFNR 2025 et la composition familiale"],
-    lien_officiel: "https://www.canada.ca/fr/agence-revenu/services/prestations-enfants-familles/allocation-canadienne-epicerie-besoins-essentiels.html",
-    criteres: {},
-  },
+  // credit-loyer-qc, credit-tps-fed, and credit-reno-fed were page-local
+  // copies of already-governed catalogue entries (issue #96, the general
+  // structural fix that also closes #93's frais-medicaux-qc-2 pattern):
+  // their montant_min/montant_max matched the catalogue so the id-based
+  // drift gate saw no active P1, but the prose had already drifted (e.g.
+  // this page's credit-reno-fed described a flat 15% rate while the
+  // catalogue documents the 2026 federal rate uncertainty). Sourcing all
+  // four entries from the catalogue removes that second, less obvious
+  // source of truth.
+  getProgrammeFromCatalogue("credit-loyer-qc"),
+  getProgrammeFromCatalogue("credit-tps-fed"),
   getProgrammeFromCatalogue("credit-maintien-qc"),
-  {
-    id: "credit-reno-fed",
-    nom: "Crédit pour rénovations multigénérationnelles",
-    organisme: "Gouvernement du Canada",
-    niveau: "federal",
-    categorie: "credits_impot",
-    montant_min: 0,
-    montant_max: 7500,
-    montant_affiche: "Jusqu'à 7 500 $",
-    description: "Crédit d'impôt remboursable de 15% pour créer un logement secondaire dans votre domicile pour un aîné ou une personne handicapée.",
-    conditions: ["Créer un logement secondaire dans votre domicile", "Le logement est destiné à un aîné (65+) ou une personne handicapée", "Dépenses admissibles entre 500 $ et 50 000 $"],
-    lien_officiel: "https://www.canada.ca/fr/agence-revenu/programmes/a-propos-agence-revenu-canada-arc/impot-cible/credit-renovation-domiciliaire-multigeneration.html",
-    criteres: { proprietaire: true, renovation: true },
-  },
+  getProgrammeFromCatalogue("credit-reno-fed"),
 ];
 
 const faqs = [

--- a/tests/programme-catalogue-drift.test.mjs
+++ b/tests/programme-catalogue-drift.test.mjs
@@ -88,6 +88,18 @@ test("isMiddlewareRedirectedRoute detects a route in middleware.ts legacyRedirec
   assert.equal(isMiddlewareRedirectedRoute("/borne-recharge-quebec", middlewareSource), false);
 });
 
+test("splitTopLevelArrayElements ignores // and /* */ comments placed between array entries (aide-lunettes-quebec pattern)", () => {
+  const arrayText = `[
+    // a leading comment explaining the next call
+    getProgrammeFromCatalogue("a"),
+    /* a block comment
+       spanning multiple lines */
+    getProgrammeFromCatalogue("b"),
+  ]`;
+  const elements = splitTopLevelArrayElements(arrayText);
+  assert.deepEqual(elements, ['getProgrammeFromCatalogue("a")', 'getProgrammeFromCatalogue("b")']);
+});
+
 test("splitTopLevelArrayElements separates object literals from catalogue calls without splitting nested criteres braces", () => {
   const arrayText = '[{ id: "a", criteres: { revenu_max: 1 } }, getProgrammeFromCatalogue("b"), { id: "c" }]';
   const elements = splitTopLevelArrayElements(arrayText);
@@ -156,6 +168,60 @@ test("a local object literal whose id already matches a catalogue entry is still
   assert.equal(violations[0].id, "credit-loyer-qc");
 });
 
+test("a local Programme hoisted into a variable and referenced in the array is still flagged (default-deny, not just literal-{} matching)", () => {
+  const pages = [
+    {
+      filePath: "src/app/some-page/page.tsx",
+      source: `
+        const localProgramme: Programme = { id: "duplicate-local", montant_min: 0, montant_max: 0 };
+        const programmes: Programme[] = [
+          localProgramme,
+          getProgrammeFromCatalogue("credit-maintien-qc"),
+        ];
+      `,
+    },
+  ];
+
+  const violations = findUngovernedLocalProgrammes({ pages });
+  assert.equal(violations.length, 1);
+  assert.equal(violations[0].id, "localProgramme");
+});
+
+test("a spread of a non-governed array is still flagged (default-deny catches any element that is not exactly getProgrammeFromCatalogue(...))", () => {
+  const pages = [
+    {
+      filePath: "src/app/some-page/page.tsx",
+      source: `
+        const programmes: Programme[] = [
+          ...localProgrammes,
+          getProgrammeFromCatalogue("credit-maintien-qc"),
+        ];
+      `,
+    },
+  ];
+
+  const violations = findUngovernedLocalProgrammes({ pages });
+  assert.equal(violations.length, 1);
+  assert.equal(violations[0].id, "...localProgrammes");
+});
+
+test("a call to a helper other than getProgrammeFromCatalogue is still flagged", () => {
+  const pages = [
+    {
+      filePath: "src/app/some-page/page.tsx",
+      source: `
+        const programmes: Programme[] = [
+          buildLocalProgramme("credit-maintien-qc"),
+        ];
+      `,
+    },
+  ];
+
+  const violations = findUngovernedLocalProgrammes({ pages });
+  assert.equal(violations.length, 1);
+  assert.equal(violations[0].id, 'buildLocalProgramme("credit-maintien-qc")');
+});
+
 test("an explicitly declared (filePath, id) exception is not flagged", () => {
   const pages = [
     {
@@ -175,7 +241,22 @@ test("an explicitly declared (filePath, id) exception is not flagged", () => {
   assert.deepEqual(violations, []);
 });
 
-test("the real src/app tree has zero pages mixing a local Programme literal into the governed array pattern (live routes only)", () => {
+// Mirrors the single, tracked, temporary exception declared in
+// governedProgrammeSourcingExceptions (scripts/check-seo.mjs): #96 found
+// that credit-impot-quebec/page.tsx duplicates 3 already-governed catalogue
+// entries, but one (credit-reno-fed) has diverging prose (a flat 15% rate
+// claim vs. the catalogue's documented 2026 rate uncertainty) - a new
+// factual duplicate discovered mid-implementation, which #96's stop
+// condition requires tracking rather than silently correcting. That
+// revalidation and migration is tracked in the dedicated follow-up issue
+// #98; this exception must be removed once #98 lands.
+const trackedGovernedProgrammeSourcingExceptions = [
+  { filePath: "src/app/credit-impot-quebec/page.tsx", id: "credit-loyer-qc" },
+  { filePath: "src/app/credit-impot-quebec/page.tsx", id: "credit-tps-fed" },
+  { filePath: "src/app/credit-impot-quebec/page.tsx", id: "credit-reno-fed" },
+];
+
+test("the real src/app tree has zero pages mixing a local Programme literal into the governed array pattern, other than the single exception tracked in issue #98 (live routes only)", () => {
   const middlewareSource = read(middlewareFile);
   const pageFiles = [];
   walkPageFiles(appDir, pageFiles);
@@ -184,15 +265,19 @@ test("the real src/app tree has zero pages mixing a local Programme literal into
     .map((filePath) => ({ filePath: relative(filePath), routePath: routePathForPageFile(filePath), source: read(filePath) }))
     .filter(({ routePath }) => !isMiddlewareRedirectedRoute(routePath, middlewareSource));
 
-  assert.deepEqual(findUngovernedLocalProgrammes({ pages }), []);
+  assert.deepEqual(findUngovernedLocalProgrammes({ pages, exceptions: trackedGovernedProgrammeSourcingExceptions }), []);
 });
 
-test("credit-impot-quebec no longer hardcodes credit-loyer-qc/credit-tps-fed/credit-reno-fed as local literals (issue #96)", () => {
+test("without the tracked #98 exception, credit-impot-quebec/page.tsx's local credit-loyer-qc/credit-tps-fed/credit-reno-fed literals are caught (proves the exception is not masking a broader gap)", () => {
   const source = read(path.join(appDir, "credit-impot-quebec", "page.tsx"));
-  assert.deepEqual(extractLocalProgrammeCopies(source), []);
-  for (const id of ["credit-loyer-qc", "credit-tps-fed", "credit-maintien-qc", "credit-reno-fed"]) {
-    assert.match(source, new RegExp(`getProgrammeFromCatalogue\\("${id}"\\)`));
-  }
+  const pages = [{ filePath: "src/app/credit-impot-quebec/page.tsx", source }];
+
+  const violations = findUngovernedLocalProgrammes({ pages });
+  assert.deepEqual(violations.map((violation) => violation.id).sort(), ["credit-loyer-qc", "credit-reno-fed", "credit-tps-fed"]);
+
+  // credit-maintien-qc must remain sourced from the catalogue (not part of
+  // the tracked exception).
+  assert.match(source, /getProgrammeFromCatalogue\("credit-maintien-qc"\)/);
 });
 
 // ── findProgrammeCatalogueDrift (fixtures) ──────────────────────────────

--- a/tests/programme-catalogue-drift.test.mjs
+++ b/tests/programme-catalogue-drift.test.mjs
@@ -9,7 +9,9 @@ import {
   extractLocalProgrammeCopies,
   extractProgrammeArrayText,
   findProgrammeCatalogueDrift,
+  findUngovernedLocalProgrammes,
   isMiddlewareRedirectedRoute,
+  splitTopLevelArrayElements,
   splitTopLevelBraceObjects,
 } from "../scripts/lib/programme-catalogue-drift.mjs";
 
@@ -84,6 +86,113 @@ test("isMiddlewareRedirectedRoute detects a route in middleware.ts legacyRedirec
   `;
   assert.equal(isMiddlewareRedirectedRoute("/allocation-logement-quebec", middlewareSource), true);
   assert.equal(isMiddlewareRedirectedRoute("/borne-recharge-quebec", middlewareSource), false);
+});
+
+test("splitTopLevelArrayElements separates object literals from catalogue calls without splitting nested criteres braces", () => {
+  const arrayText = '[{ id: "a", criteres: { revenu_max: 1 } }, getProgrammeFromCatalogue("b"), { id: "c" }]';
+  const elements = splitTopLevelArrayElements(arrayText);
+  assert.equal(elements.length, 3);
+  assert.match(elements[0], /"a"/);
+  assert.equal(elements[1], 'getProgrammeFromCatalogue("b")');
+  assert.match(elements[2], /"c"/);
+});
+
+// ── findUngovernedLocalProgrammes (issue #96) ───────────────────────────
+// General fix for the gap left open by #93: id-based drift detection can
+// only compare a local copy against a catalogue entry that shares its id.
+// findUngovernedLocalProgrammes instead rejects any raw object literal in
+// the governed array, whatever id it declares - so a page cannot smuggle
+// in a duplicate benefit just by inventing a local id with no catalogue
+// counterpart, which is exactly what frais-medicaux-qc-2/-fed did.
+
+test("reproduces the historical frais-medicaux-qc-2/frais-medicaux-fed-2 pattern (issue #93): a local id with no catalogue counterpart is still caught", () => {
+  const pages = [
+    {
+      filePath: "src/app/credit-impot-frais-medicaux-quebec/page.tsx",
+      source: `
+        const programmes: Programme[] = [
+          { id: "frais-medicaux-qc-2", montant_min: 0, montant_max: 0, montant_affiche: "x" },
+          { id: "frais-medicaux-fed-2", montant_min: 0, montant_max: 0, montant_affiche: "x" },
+        ];
+      `,
+    },
+  ];
+
+  const violations = findUngovernedLocalProgrammes({ pages });
+  assert.equal(violations.length, 2);
+  assert.deepEqual(violations.map((violation) => violation.id).sort(), ["frais-medicaux-fed-2", "frais-medicaux-qc-2"]);
+});
+
+test("a page fully sourced via getProgrammeFromCatalogue produces no violation", () => {
+  const pages = [
+    {
+      filePath: "src/app/credit-impot-frais-medicaux-quebec/page.tsx",
+      source: `
+        const programmes: Programme[] = [
+          getProgrammeFromCatalogue("credit-frais-medicaux-qc"),
+          getProgrammeFromCatalogue("credit-frais-medicaux-fed"),
+        ];
+      `,
+    },
+  ];
+
+  assert.deepEqual(findUngovernedLocalProgrammes({ pages }), []);
+});
+
+test("a local object literal whose id already matches a catalogue entry is still flagged (duplicate source of truth, even with no active montant drift)", () => {
+  const pages = [
+    {
+      filePath: "src/app/credit-impot-quebec/page.tsx",
+      source: `
+        const programmes: Programme[] = [
+          { id: "credit-loyer-qc", montant_min: 0, montant_max: 0, montant_affiche: "x" },
+        ];
+      `,
+    },
+  ];
+
+  const violations = findUngovernedLocalProgrammes({ pages });
+  assert.equal(violations.length, 1);
+  assert.equal(violations[0].id, "credit-loyer-qc");
+});
+
+test("an explicitly declared (filePath, id) exception is not flagged", () => {
+  const pages = [
+    {
+      filePath: "src/app/some-page/page.tsx",
+      source: `
+        const programmes: Programme[] = [
+          { id: "programme-local-uniquement", montant_min: 0, montant_max: 100, montant_affiche: "x" },
+        ];
+      `,
+    },
+  ];
+
+  const violations = findUngovernedLocalProgrammes({
+    pages,
+    exceptions: [{ filePath: "src/app/some-page/page.tsx", id: "programme-local-uniquement" }],
+  });
+  assert.deepEqual(violations, []);
+});
+
+test("the real src/app tree has zero pages mixing a local Programme literal into the governed array pattern (live routes only)", () => {
+  const middlewareSource = read(middlewareFile);
+  const pageFiles = [];
+  walkPageFiles(appDir, pageFiles);
+
+  const pages = pageFiles
+    .map((filePath) => ({ filePath: relative(filePath), routePath: routePathForPageFile(filePath), source: read(filePath) }))
+    .filter(({ routePath }) => !isMiddlewareRedirectedRoute(routePath, middlewareSource));
+
+  assert.deepEqual(findUngovernedLocalProgrammes({ pages }), []);
+});
+
+test("credit-impot-quebec no longer hardcodes credit-loyer-qc/credit-tps-fed/credit-reno-fed as local literals (issue #96)", () => {
+  const source = read(path.join(appDir, "credit-impot-quebec", "page.tsx"));
+  assert.deepEqual(extractLocalProgrammeCopies(source), []);
+  for (const id of ["credit-loyer-qc", "credit-tps-fed", "credit-maintien-qc", "credit-reno-fed"]) {
+    assert.match(source, new RegExp(`getProgrammeFromCatalogue\\("${id}"\\)`));
+  }
 });
 
 // ── findProgrammeCatalogueDrift (fixtures) ──────────────────────────────


### PR DESCRIPTION
Closes #96

## Root cause

`checkProgrammeCatalogueDrift()` (issue #69) ne détecte une dérive que lorsqu'une page réutilise **le même id** qu'une entrée du catalogue et que les montants divergent. Le scénario #93 (`frais-medicaux-qc-2` / `frais-medicaux-fed-2`) a montré qu'une page peut recréer un bénéfice déjà gouverné sous un **id local différent** sans être détectée : il n'y a alors aucun id partagé sur lequel comparer.

## Invariant choisi et pourquoi

Ajout de `findUngovernedLocalProgrammes()` dans `scripts/lib/programme-catalogue-drift.mjs` : un invariant **structurel et déterministe**, pas une heuristique sémantique. Toute page qui adopte le pattern gouverné `const programmes: Programme[] = [...]` (celui consommé par `SeoProgrammesPage`) doit sourcer **chaque entrée** via `getProgrammeFromCatalogue(id)`. Le check est **default-deny** : tout élément top-level du tableau qui n'est pas *exactement* un appel `getProgrammeFromCatalogue("id")` est rejeté — objet littéral `{ id: ..., ... }`, variable hoisted (`const x = {...}; programmes = [x]`), `...spread`, ou tout autre helper. `splitTopLevelArrayElements()` neutralise aussi les commentaires `//`/`/* */` placés entre deux entrées avant de découper, pour ne pas les compter comme des éléments.

Toute exception légitime doit être déclarée explicitement dans `governedProgrammeSourcingExceptions` (`scripts/check-seo.mjs`) — voir plus bas, une seule y figure actuellement, temporaire.

Le garde-fou ciblé de #93 (la doc/commentaire sur `credit-impot-frais-medicaux-quebec/page.tsx`) reste en place; il devient un cas particulier couvert par la protection générale, donc redondant mais inoffensif — non supprimé pour ne pas élargir le diff.

## Fichiers modifiés

- `scripts/lib/programme-catalogue-drift.mjs` : `splitTopLevelArrayElements()`, `blankComments()`, `findUngovernedLocalProgrammes()`.
- `scripts/check-seo.mjs` : câblage du nouveau check dans `checkProgrammeCatalogueDrift()`, déclaration de `governedProgrammeSourcingExceptions` (3 entrées temporaires, voir plus bas).
- `tests/programme-catalogue-drift.test.mjs` : reproduction du scénario #93, cas id local déjà présent dans le catalogue, contournement par variable hoisted / spread / autre helper, commentaires entre entrées, exception explicite respectée, arbre `src/app` réel.
- `src/app/credit-impot-quebec/page.tsx` : **non modifiée en contenu.** Une première itération l'avait migrée vers le catalogue après avoir découvert un doublon (voir ci-dessous); la revue indépendante a signalé que ceci contrevenait au STOP de #96, et la page a été restaurée à son contenu d'origine.

## Scénario de régression reproduit

`findUngovernedLocalProgrammes` reproduit exactement le pattern `frais-medicaux-qc-2` / `frais-medicaux-fed-2` (id local sans équivalent catalogue) et confirme qu'il aurait été bloqué automatiquement — ainsi que les contournements par indirection (variable hoisted, spread, autre helper) qu'une première itération de l'implémentation laissait passer, corrigés avant tout merge suite à la revue indépendante.

## Nouveau doublon factuel découvert pendant l'implémentation (non corrigé dans cette PR)

En appliquant le nouvel invariant à l'arbre réel, `src/app/credit-impot-quebec/page.tsx` s'est révélée dupliquer localement `credit-loyer-qc`, `credit-tps-fed` et `credit-reno-fed` — mêmes `montant_min`/`montant_max` que le catalogue (donc aucune dérive P1 déjà détectée), mais deuxième source de vérité. Le texte local de `credit-reno-fed` affirme un taux fixe de 15%, alors que le catalogue documente déjà une incertitude sur le taux fédéral 2026 pour ce crédit (14% généralisé vs maintien possible à 15%).

Conformément au STOP explicite de #96 (« si un nouveau doublon factuel actif est découvert pendant l'implémentation, STOP et documenter le finding plutôt que d'élargir silencieusement le scope »), **ce contenu financier n'est pas modifié dans cette PR**. Il est documenté et tracké dans le suivi dédié **#98** (revalidation factuelle du taux + migration ultérieure vers le catalogue).

## Exceptions

Une seule, explicite, bornée et **temporaire** : `governedProgrammeSourcingExceptions` (`scripts/check-seo.mjs`) déclare `src/app/credit-impot-quebec/page.tsx` pour `credit-loyer-qc`, `credit-tps-fed` et `credit-reno-fed`, avec un commentaire renvoyant vers #98. Un test dédié prouve qu'en l'absence de cette exception, le garde-fou général signale bien ces 3 mêmes id (l'exception ne masque pas un trou plus large). Elle doit être retirée une fois #98 résolue.

## Tests / gates exécutés (SHA final)

- Tests ciblés (`node --test tests/programme-catalogue-drift.test.mjs`) : 31/31 PASS.
- `npm run test:unit` : 264/264 PASS.
- `npm run check:seo` : PASS.
- `npm run lint` : PASS (aucune sortie).
- `npm run build` : PASS (build Next.js complet, toutes les routes prerendered).
- `git diff --check` : propre.

SHA final : `8d25c7355f7842533ec9ed653be16ae53463c33c`.
Deploy Preview Netlify : SUCCESS sur ce SHA.

## Hors périmètre (non touché)

Revalidation Bell/TekSavvy (#79), SRG/SV oct-déc (#80), refonte générale de `programmes.json`, migration massive d'autres pages, nouvelle architecture de contenu.

## Historique de la revue

Une première itération de cette PR (SHA `9f5c5c7`) avait un garde-fou contournable par indirection (variable hoisted/spread) et migrait silencieusement `credit-impot-quebec/page.tsx` vers le catalogue en réponse au doublon découvert, en violation du STOP de #96. La revue indépendante a signalé ces deux points; ils sont corrigés dans le SHA final ci-dessus. Rapport durable complet publié dans #96.

## Stop condition

Protection implémentée, testée, PR ouverte et corrigée suite à revue. Ne pas merger sans la décision du Product Owner / reviewer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018b42FfErti9uqeYpa52TdD