### PR TITLE
Revalide et migre credit-impot-quebec/page.tsx vers le catalogue (issue #98)

### DIFF
--- a/scripts/check-seo.mjs
+++ b/scripts/check-seo.mjs
@@ -56,23 +56,13 @@ const legitimateSeoRegistryExceptions = [
 // Pages explicitly allowed to keep a raw local Programme object literal
 // inside the governed `const programmes: Programme[] = [...]` array
 // instead of sourcing it via getProgrammeFromCatalogue (issue #96). Every
-// entry here must be a one-line justification and, other than this single
-// tracked case, must never be used to silence a real duplicate:
-//
-// - credit-impot-quebec/page.tsx: credit-loyer-qc, credit-tps-fed, and
-//   credit-reno-fed already match the catalogue's montant_min/montant_max
-//   exactly (no active P1 drift), but their prose has diverged from the
-//   catalogue - notably credit-reno-fed's flat "15%" rate claim vs. the
-//   catalogue's documented 2026 federal rate uncertainty. Per #96's stop
-//   condition, that factual divergence is tracked and revalidated in
-//   follow-up issue #98 rather than silently corrected here; this
-//   exception is temporary and must be removed once #98 migrates these
-//   three entries onto getProgrammeFromCatalogue(...).
-const governedProgrammeSourcingExceptions = [
-  { filePath: "src/app/credit-impot-quebec/page.tsx", id: "credit-loyer-qc" }, // tracked in #98
-  { filePath: "src/app/credit-impot-quebec/page.tsx", id: "credit-tps-fed" }, // tracked in #98
-  { filePath: "src/app/credit-impot-quebec/page.tsx", id: "credit-reno-fed" }, // tracked in #98
-];
+// entry here must be a one-line justification and must never be used to
+// silence a real duplicate. Currently empty: the temporary exception for
+// credit-impot-quebec/page.tsx (credit-loyer-qc, credit-tps-fed,
+// credit-reno-fed) was removed once issue #98 revalidated credit-reno-fed's
+// rate against an official ARC source and migrated all three entries onto
+// getProgrammeFromCatalogue(...).
+const governedProgrammeSourcingExceptions = [];
 
 const errors = [];
 

--- a/src/app/credit-impot-quebec/page.tsx
+++ b/src/app/credit-impot-quebec/page.tsx
@@ -10,65 +10,11 @@ export const metadata: Metadata = {
   keywords: ["crédit impôt Québec", "crédit impôt Québec combien", "crédits impôt remboursables Québec 2026", "récupérer impôt Québec"],
 };
 
-// credit-loyer-qc, credit-tps-fed, and credit-reno-fed below are page-local
-// copies of already-governed catalogue entries, caught by the new
-// findUngovernedLocalProgrammes() structural check (issue #96). Their
-// montant_min/montant_max match the catalogue exactly (no active P1 drift),
-// but the prose has already diverged - notably credit-reno-fed's flat 15%
-// rate claim vs. the catalogue's documented 2026 federal rate uncertainty.
-// Per #96's stop condition, that factual divergence is not corrected here:
-// it is tracked and revalidated in the dedicated follow-up issue #98, which
-// will migrate these three entries onto getProgrammeFromCatalogue(...) once
-// the rate is confirmed. Until then they are a declared, temporary
-// exception in governedProgrammeSourcingExceptions (scripts/check-seo.mjs).
 const programmes: Programme[] = [
-  {
-    id: "credit-loyer-qc",
-    nom: "Crédit d'impôt pour solidarité",
-    organisme: "Revenu Québec",
-    niveau: "provincial",
-    categorie: "credits_impot",
-    montant_min: 0,
-    montant_max: 0,
-    montant_affiche: "Montant déterminé par Revenu Québec — à vérifier",
-    montant_sommable: false,
-    preselection_only: true,
-    description: "Crédit d'impôt remboursable combinant jusqu'à trois composantes : TVQ, logement et village nordique (pour les 14 villages nordiques du Nunavik). Montant et fréquence de versement déterminés par Revenu Québec selon le dossier complet.",
-    conditions: ["Résider au Québec au 31 décembre 2025", "Produire la déclaration de revenus 2025 et l'annexe D si le logement ou le village nordique s'appliquent", "Faire vérifier le montant par Revenu Québec"],
-    lien_officiel: "https://www.revenuquebec.ca/fr/citoyens/credits-dimpot/credit-dimpot-pour-solidarite/",
-    criteres: { provinces: ["QC"] },
-  },
-  {
-    id: "credit-tps-fed",
-    nom: "Allocation canadienne pour l’épicerie et les besoins essentiels (ACEBE)",
-    organisme: "Gouvernement du Canada",
-    niveau: "federal",
-    categorie: "credits_impot",
-    montant_min: 0,
-    montant_max: 0,
-    montant_affiche: "Montant calculé par l’ARC — à vérifier",
-    montant_sommable: false,
-    preselection_only: true,
-    description: "Prestation fédérale trimestrielle non imposable qui remplace le crédit pour la TPS/TVH depuis juillet 2026.",
-    conditions: ["Résider au Canada", "Produire une déclaration de revenus fédérale", "Faire vérifier le montant selon le RFNR 2025 et la composition familiale"],
-    lien_officiel: "https://www.canada.ca/fr/agence-revenu/services/prestations-enfants-familles/allocation-canadienne-epicerie-besoins-essentiels.html",
-    criteres: {},
-  },
+  getProgrammeFromCatalogue("credit-loyer-qc"),
+  getProgrammeFromCatalogue("credit-tps-fed"),
   getProgrammeFromCatalogue("credit-maintien-qc"),
-  {
-    id: "credit-reno-fed",
-    nom: "Crédit pour rénovations multigénérationnelles",
-    organisme: "Gouvernement du Canada",
-    niveau: "federal",
-    categorie: "credits_impot",
-    montant_min: 0,
-    montant_max: 7500,
-    montant_affiche: "Jusqu'à 7 500 $",
-    description: "Crédit d'impôt remboursable de 15% pour créer un logement secondaire dans votre domicile pour un aîné ou une personne handicapée.",
-    conditions: ["Créer un logement secondaire dans votre domicile", "Le logement est destiné à un aîné (65+) ou une personne handicapée", "Dépenses admissibles entre 500 $ et 50 000 $"],
-    lien_officiel: "https://www.canada.ca/fr/agence-revenu/programmes/a-propos-agence-revenu-canada-arc/impot-cible/credit-renovation-domiciliaire-multigeneration.html",
-    criteres: { proprietaire: true, renovation: true },
-  },
+  getProgrammeFromCatalogue("credit-reno-fed"),
 ];
 
 const faqs = [

--- a/src/data/programmes.json
+++ b/src/data/programmes.json
@@ -188,13 +188,13 @@
     "niveau": "federal",
     "categorie": "renovation",
     "montant_min": 0,
-    "montant_max": 7250,
-    "montant_affiche": "Jusqu'à 7 250 $ (déclaration de revenus 2025)",
-    "description": "Crédit d'impôt remboursable sur les dépenses admissibles (max 50 000 $) pour créer un logement secondaire pour un aîné ou une personne handicapée. Revalidé le 2026-09-05 (issue #98) directement sur la page officielle de l'ARC dédiée à ce crédit (ligne 45355, ministère du Revenu du Canada, mise à jour du 20 janvier 2026) : le taux applicable aux dépenses de l'année d'imposition 2025 (déclarée en 2026) est de 14,5 %, pour un crédit maximal de 7 250 $ — et non le taux fixe de 15 % (7 500 $) précédemment affiché sur cette page, ni un taux de 14 % plat. Ce 14,5 % reflète le passage en cours d'année du premier taux d'imposition fédéral de 15 % à 14 % (1er juillet 2025), auquel ce crédit est arrimé; il devrait redescendre à 14 % (7 000 $) pour l'année d'imposition 2026 complète, à confirmer lors d'une prochaine revalidation.",
+    "montant_max": 7000,
+    "montant_affiche": "Jusqu'à 7 000 $ (année d'imposition 2026)",
+    "description": "Crédit d'impôt remboursable de 14 % sur les dépenses admissibles (max 50 000 $) pour créer un logement secondaire pour un aîné ou une personne handicapée, pour un crédit maximal de 7 000 $ en 2026. Revalidé le 2026-09-05 (issue #98) : ce crédit est arrimé au taux d'imposition le plus bas du barème fédéral (Loi de l'impôt sur le revenu, art. 122.92 et par. 248(1)), fixé à 14 % pour l'année d'imposition 2026 et les suivantes par la Loi de 2026 sur l'abordabilité, et confirmé par les taux d'imposition 2026 de l'Agence du revenu du Canada (ARC) ainsi que par le rapport du ministère des Finances sur les dépenses fiscales fédérales 2026. Pour l'année d'imposition 2025 (déclarée en 2026), le taux transitoire était de 14,5 % (7 250 $), en raison du passage en cours d'année du taux fédéral de 15 % à 14 % le 1er juillet 2025 — cette valeur 2025 ne s'applique plus aux dépenses de 2026.",
     "conditions": [
       "Créer un logement secondaire dans votre domicile",
       "Le logement est destiné à un aîné (65+) ou une personne handicapée",
-      "Dépenses admissibles minimales de 500 $"
+      "Dépenses admissibles maximales de 50 000 $"
     ],
     "lien_officiel": "https://www.canada.ca/fr/agence-revenu/services/impot/particuliers/sujets/tout-votre-declaration-revenus/declaration-revenus/remplir-declaration-revenus/deductions-credits-depenses/ligne-45355-cirhm.html",
     "criteres": {

--- a/src/data/programmes.json
+++ b/src/data/programmes.json
@@ -188,9 +188,9 @@
     "niveau": "federal",
     "categorie": "renovation",
     "montant_min": 0,
-    "montant_max": 7500,
-    "montant_affiche": "Jusqu'à 7 500 $",
-    "description": "Crédit d'impôt remboursable de 15 % sur les dépenses admissibles (max 50 000 $) pour créer un logement secondaire pour un aîné ou une personne handicapée. Le taux fédéral le plus bas est passé à 14 % en 2026 pour la plupart des crédits non remboursables, mais un mécanisme distinct pourrait maintenir certains crédits (dont potentiellement celui-ci) à 15 % jusqu'en 2030; le taux exact applicable à ce crédit précis n'a pas pu être confirmé directement auprès de l'ARC dans cet audit.",
+    "montant_max": 7250,
+    "montant_affiche": "Jusqu'à 7 250 $ (déclaration de revenus 2025)",
+    "description": "Crédit d'impôt remboursable sur les dépenses admissibles (max 50 000 $) pour créer un logement secondaire pour un aîné ou une personne handicapée. Revalidé le 2026-09-05 (issue #98) directement sur la page officielle de l'ARC dédiée à ce crédit (ligne 45355, ministère du Revenu du Canada, mise à jour du 20 janvier 2026) : le taux applicable aux dépenses de l'année d'imposition 2025 (déclarée en 2026) est de 14,5 %, pour un crédit maximal de 7 250 $ — et non le taux fixe de 15 % (7 500 $) précédemment affiché sur cette page, ni un taux de 14 % plat. Ce 14,5 % reflète le passage en cours d'année du premier taux d'imposition fédéral de 15 % à 14 % (1er juillet 2025), auquel ce crédit est arrimé; il devrait redescendre à 14 % (7 000 $) pour l'année d'imposition 2026 complète, à confirmer lors d'une prochaine revalidation.",
     "conditions": [
       "Créer un logement secondaire dans votre domicile",
       "Le logement est destiné à un aîné (65+) ou une personne handicapée",

--- a/tests/programme-catalogue-drift.test.mjs
+++ b/tests/programme-catalogue-drift.test.mjs
@@ -241,22 +241,20 @@ test("an explicitly declared (filePath, id) exception is not flagged", () => {
   assert.deepEqual(violations, []);
 });
 
-// Mirrors the single, tracked, temporary exception declared in
-// governedProgrammeSourcingExceptions (scripts/check-seo.mjs): #96 found
-// that credit-impot-quebec/page.tsx duplicates 3 already-governed catalogue
-// entries, but one (credit-reno-fed) has diverging prose (a flat 15% rate
-// claim vs. the catalogue's documented 2026 rate uncertainty) - a new
-// factual duplicate discovered mid-implementation, which #96's stop
-// condition requires tracking rather than silently correcting. That
-// revalidation and migration is tracked in the dedicated follow-up issue
-// #98; this exception must be removed once #98 lands.
-const trackedGovernedProgrammeSourcingExceptions = [
-  { filePath: "src/app/credit-impot-quebec/page.tsx", id: "credit-loyer-qc" },
-  { filePath: "src/app/credit-impot-quebec/page.tsx", id: "credit-tps-fed" },
-  { filePath: "src/app/credit-impot-quebec/page.tsx", id: "credit-reno-fed" },
-];
+// issue #98: credit-impot-quebec/page.tsx used to keep credit-loyer-qc,
+// credit-tps-fed, and credit-reno-fed as page-local Programme literals (a
+// temporary, tracked exception in governedProgrammeSourcingExceptions,
+// scripts/check-seo.mjs) because credit-reno-fed's prose had a flat 15%
+// rate claim that needed revalidating against an official ARC source before
+// being migrated onto the catalogue. That revalidation found the ARC's own
+// page for this credit (line 45355, updated 5 January 2026) states 14.5% /
+// $7,250 for 2025 tax-year expenses (a mid-year blend of the 15%->14%
+// federal rate cut on 1 July 2025) - neither of the two rates the finding
+// asked to arbitrate between. programmes.json's credit-reno-fed entry was
+// corrected accordingly and all three ids are now sourced from the
+// catalogue; the exception is removed (empty array).
 
-test("the real src/app tree has zero pages mixing a local Programme literal into the governed array pattern, other than the single exception tracked in issue #98 (live routes only)", () => {
+test("the real src/app tree has zero pages mixing a local Programme literal into the governed array pattern (live routes only)", () => {
   const middlewareSource = read(middlewareFile);
   const pageFiles = [];
   walkPageFiles(appDir, pageFiles);
@@ -265,19 +263,25 @@ test("the real src/app tree has zero pages mixing a local Programme literal into
     .map((filePath) => ({ filePath: relative(filePath), routePath: routePathForPageFile(filePath), source: read(filePath) }))
     .filter(({ routePath }) => !isMiddlewareRedirectedRoute(routePath, middlewareSource));
 
-  assert.deepEqual(findUngovernedLocalProgrammes({ pages, exceptions: trackedGovernedProgrammeSourcingExceptions }), []);
+  assert.deepEqual(findUngovernedLocalProgrammes({ pages, exceptions: [] }), []);
 });
 
-test("without the tracked #98 exception, credit-impot-quebec/page.tsx's local credit-loyer-qc/credit-tps-fed/credit-reno-fed literals are caught (proves the exception is not masking a broader gap)", () => {
+test("credit-impot-quebec/page.tsx sources credit-loyer-qc, credit-tps-fed, credit-maintien-qc, and credit-reno-fed from the catalogue instead of page-local copies (issue #98)", () => {
   const source = read(path.join(appDir, "credit-impot-quebec", "page.tsx"));
-  const pages = [{ filePath: "src/app/credit-impot-quebec/page.tsx", source }];
 
-  const violations = findUngovernedLocalProgrammes({ pages });
-  assert.deepEqual(violations.map((violation) => violation.id).sort(), ["credit-loyer-qc", "credit-reno-fed", "credit-tps-fed"]);
+  assert.deepEqual(extractLocalProgrammeCopies(source), []);
+  for (const id of ["credit-loyer-qc", "credit-tps-fed", "credit-maintien-qc", "credit-reno-fed"]) {
+    assert.match(source, new RegExp(`getProgrammeFromCatalogue\\("${id}"\\)`));
+  }
+});
 
-  // credit-maintien-qc must remain sourced from the catalogue (not part of
-  // the tracked exception).
-  assert.match(source, /getProgrammeFromCatalogue\("credit-maintien-qc"\)/);
+test("catalogue's credit-reno-fed reflects the issue #98 ARC revalidation (14.5% / $7,250 for the 2025 tax year, not the prior flat 15% / $7,500 claim)", () => {
+  const catalogue = JSON.parse(read(programmesJsonFile));
+  const renoFed = catalogue.find((programme) => programme.id === "credit-reno-fed");
+
+  assert.equal(renoFed.montant_max, 7250);
+  assert.match(renoFed.description, /14,5 ?%/);
+  assert.doesNotMatch(renoFed.description, /remboursable de 15 ?%/);
 });
 
 // ── findProgrammeCatalogueDrift (fixtures) ──────────────────────────────

--- a/tests/programme-catalogue-drift.test.mjs
+++ b/tests/programme-catalogue-drift.test.mjs
@@ -246,13 +246,17 @@ test("an explicitly declared (filePath, id) exception is not flagged", () => {
 // temporary, tracked exception in governedProgrammeSourcingExceptions,
 // scripts/check-seo.mjs) because credit-reno-fed's prose had a flat 15%
 // rate claim that needed revalidating against an official ARC source before
-// being migrated onto the catalogue. That revalidation found the ARC's own
-// page for this credit (line 45355, updated 5 January 2026) states 14.5% /
-// $7,250 for 2025 tax-year expenses (a mid-year blend of the 15%->14%
-// federal rate cut on 1 July 2025) - neither of the two rates the finding
-// asked to arbitrate between. programmes.json's credit-reno-fed entry was
-// corrected accordingly and all three ids are now sourced from the
-// catalogue; the exception is removed (empty array).
+// being migrated onto the catalogue. This credit is legally arrimé to the
+// lowest federal bracket rate (Income Tax Act s.122.92 and s.248(1)),
+// confirmed at 14% for the 2026 tax year onward by the Loi de 2026 sur
+// l'abordabilité, the ARC's 2026 tax rates, and the Department of Finance's
+// 2026 tax expenditures report - so credit-reno-fed's catalogue entry is
+// 14% / $7,000 for the 2026 tax year (not the prior flat 15% / $7,500
+// claim, and not the transitional 14.5% / $7,250 that applied only to 2025
+// tax-year expenses during the mid-year 15%->14% rate cut on 1 July 2025).
+// programmes.json's credit-reno-fed entry was corrected accordingly and all
+// three ids are now sourced from the catalogue; the exception is removed
+// (empty array).
 
 test("the real src/app tree has zero pages mixing a local Programme literal into the governed array pattern (live routes only)", () => {
   const middlewareSource = read(middlewareFile);
@@ -275,13 +279,16 @@ test("credit-impot-quebec/page.tsx sources credit-loyer-qc, credit-tps-fed, cred
   }
 });
 
-test("catalogue's credit-reno-fed reflects the issue #98 ARC revalidation (14.5% / $7,250 for the 2025 tax year, not the prior flat 15% / $7,500 claim)", () => {
+test("catalogue's credit-reno-fed reflects the issue #98 ARC revalidation for the 2026 tax year (14% / $7,000, not the prior flat 15% / $7,500 claim nor the 2025-only transitional 14.5% / $7,250)", () => {
   const catalogue = JSON.parse(read(programmesJsonFile));
   const renoFed = catalogue.find((programme) => programme.id === "credit-reno-fed");
 
-  assert.equal(renoFed.montant_max, 7250);
-  assert.match(renoFed.description, /14,5 ?%/);
+  assert.equal(renoFed.montant_max, 7000);
+  assert.match(renoFed.description, /remboursable de 14 ?%/);
   assert.doesNotMatch(renoFed.description, /remboursable de 15 ?%/);
+  assert.doesNotMatch(renoFed.montant_affiche, /7 ?250/);
+  assert.doesNotMatch(renoFed.description, /Dépenses admissibles minimales de 500/);
+  assert.deepEqual(renoFed.conditions, ["Créer un logement secondaire dans votre domicile", "Le logement est destiné à un aîné (65+) ou une personne handicapée", "Dépenses admissibles maximales de 50 000 $"]);
 });
 
 // ── findProgrammeCatalogueDrift (fixtures) ──────────────────────────────


### PR DESCRIPTION
Closes https://github.com/Simultima-qc/argentqc/issues/98

## Contexte

Finding de la revue indépendante sur #96/PR #97 : `src/app/credit-impot-quebec/page.tsx` définissait localement trois `Programme` (`credit-loyer-qc`, `credit-tps-fed`, `credit-reno-fed`) dont l'id coïncidait déjà avec une entrée gouvernée de `src/data/programmes.json`. Les montants correspondaient (pas de dérive P1 active), mais la prose avait divergé — notamment `credit-reno-fed` qui affichait un taux fixe de 15 % pendant que le catalogue documentait une incertitude 2026 non revalidée (14 % vs 15 %).

## Mandat #1 — Revalidation factuelle du taux (avant toute modification)

Vérité canonique retenue, sourcée sur les textes de loi primaires (revalidée deux fois, dont une correction suite à la revue du Product Owner sur cette PR) :

- **Année d'imposition 2026 (valeur canonique du catalogue) : 14 % / 7 000 $** (14 % × 50 000 $ de dépenses admissibles). Ce crédit est arrimé au taux d'imposition fédéral le plus bas (Loi de l'impôt sur le revenu, art. 122.92 et par. 248(1)), fixé à 14 % pour 2026 et les années suivantes par la Loi de 2026 sur l'abordabilité, et confirmé par les taux d'imposition 2026 de l'Agence du revenu du Canada (ARC) ainsi que par le rapport du ministère des Finances sur les dépenses fiscales fédérales 2026.
- **Année d'imposition 2025 (déclarée en 2026) : 14,5 % / 7 250 $**, conservée uniquement comme contexte historique dans la description — taux transitoire dû au passage en cours d'année du taux fédéral de 15 % à 14 % le 1er juillet 2025. Cette valeur 2025 n'est **pas** la valeur canonique du catalogue.
- Ni le 15 % / 7 500 $ précédemment affiché sur la page, ni un 14 % plat sans plafond correct, ne sont retenus.
- Le seuil « dépenses admissibles minimales de 500 $ » a été retiré : aucune source primaire (l'art. 122.92 ne prévoit qu'un plafond de 50 000 $, pas de plancher).

`src/data/programmes.json` (`credit-reno-fed`) : `montant_max` = 7000, `montant_affiche` et `description` reflètent 14 %/7 000 $ (2026) avec la nuance 2025 en contexte, source « Agence du revenu du Canada (ARC) ».

## Mandat #2-4 — Migration

- `src/app/credit-impot-quebec/page.tsx` : les 4 entrées (`credit-loyer-qc`, `credit-tps-fed`, `credit-maintien-qc`, `credit-reno-fed`) sourcées via `getProgrammeFromCatalogue(...)`, plus aucun `Programme` local dans cette page.
- `scripts/check-seo.mjs` : l'exception temporaire `governedProgrammeSourcingExceptions` (introduite par #97) vidée — plus aucune page ne contourne la gouvernance du catalogue.
- `tests/programme-catalogue-drift.test.mjs` : tests mis à jour pour verrouiller la migration (aucune copie locale restante), la valeur canonique 14 %/7 000 $ de `credit-reno-fed`, et l'absence du seuil de 500 $ non sourcé — suivant le pattern des migrations précédentes (#69, #86, #88, #93).

## Hors périmètre

Aucune autre valeur fiscale modifiée. `credit-impot-reno-fed` (CIHA, ligne 31285 — crédit distinct au même mécanisme de taux) n'est pas touché ici.

## Historique de revue

Une première revue du Product Owner a signalé que la revalidation initiale avait retenu le taux transitoire 2025 (14,5 %/7 250 $) au lieu du taux 2026 demandé par #98 ; corrigé au commit `6281812` avec les sources légales citées dans la revue (LIR art. 122.92/248(1), Loi de 2026 sur l'abordabilité, taux ARC 2026, rapport du ministère des Finances 2026). Une seconde revue a validé le fond sur `6281812` et demandé uniquement cette mise à jour du corps de la PR pour rester cohérent avec le SHA final.

## Commandes exécutées (toutes vertes sur le SHA final `6281812`)

- `npm run check:seo` ✅
- `npm run test:unit` — 265/265 ✅
- `npm run lint` ✅
- `npm run build` (inclut `check:seo` + `next build`) ✅
- `git diff --check` ✅
- Deploy Preview Netlify : SUCCESS sur `6281812`

## Findings

Aucun P0/P1/P2 résiduel dans le périmètre de cette issue.

## GO/NO-GO

GO — revalidation sourcée sur les textes de loi primaires, migration complète, gates verts, aucune régression détectée, revue du Product Owner favorable sur le SHA final.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GS3i1JNZh6yUR9ii6UTswG